### PR TITLE
Feat/scoping verification

### DIFF
--- a/examples/example.svi
+++ b/examples/example.svi
@@ -5,4 +5,4 @@ if x = 1 then
 else
     x := 3;
 fi 
-{ Forall i in [0, 3) . (x = 1) && true };
+{ Forall i in [0; 3) . (x = 2) && true };

--- a/examples/verifier_tests/pass_test/pltl_scope.svi
+++ b/examples/verifier_tests/pass_test/pltl_scope.svi
@@ -3,14 +3,18 @@ x := 3.14;
 
 i : Int;
 i := 0;
+y: Float;
 while i < 10 do
     x : Float;
     x := 0.5 * i;
+    y := x;
     i := i + 1;
     
-    // SelVeri-trick: in loops, to capture specific iterations, one must use index-implication.
-    { Once ((i = 1) => (x = 0)) }; // true, just
-    { Once ((i = 1) => (x = 0.5)) };
+    { Once ((i = 1) => (x = 0)) }; // holds just after i becomes 1.
+    { Once ((i = 1) => (x = 0.5)) }; // holds just before i becomes 2.
+
+    { Historically((x = 0.5 * i) || x = 0.5 * (i-1)) };
+    
 
     // IMPORTANT NOTE: Because of unique scope IDs, the inner x is now a BRAND NEW 
     //                 variable for every iteration! Its history resets every loop.
@@ -18,6 +22,12 @@ while i < 10 do
     //                 what it was initialized to in this specific iteration.
     //                 
 od
+
+// SelVeri-trick: in loops, to capture specific iterations, one must use loop-variant-conjuction, after the loop ends
+{ Once ((i = 1) && (y = 0)) }; // holds just after i becomes 1.
+{ Once ((i = 1) && (y = 0.5)) }; // holds just before i becomes 2.
+{ Once ((i = 10) && (y = 4.5)) }; // holds just before i becomes 11.
+{ Historically((y = 0.5 * i) || y = 0.5 * (i-1)) };
 
 
 if 2 > 1 then

--- a/examples/verifier_tests/pass_test/pltl_scope.svi
+++ b/examples/verifier_tests/pass_test/pltl_scope.svi
@@ -1,0 +1,31 @@
+x : Float;
+x := 3.14;
+
+i : Int;
+i := 0;
+while i < 10 do
+    x : Float;
+    x := 0.5 * i;
+    i := i + 1;
+    
+    // SelVeri-trick: in loops, to capture specific iterations, one must use index-implication.
+    { Once ((i = 1) => (x = 0)) }; // true, just
+    { Once ((i = 1) => (x = 0.5)) };
+
+    // IMPORTANT NOTE: Because of unique scope IDs, the inner x is now a BRAND NEW 
+    //                 variable for every iteration! Its history resets every loop.
+    //                 Therefore, it is never 0.0 at iteration 2; it is only exactly
+    //                 what it was initialized to in this specific iteration.
+    //                 
+od
+
+
+if 2 > 1 then
+    x : Int;
+    x := 33;
+    { Historically(x = 33) }; // This is independent of all other x, so this spec holds.
+fi
+
+x := 3.14;
+
+{ Historically(x = 3.14) };

--- a/src/selveri/SelVerifier/mapper.py
+++ b/src/selveri/SelVerifier/mapper.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import Any, Dict
 from z3 import *
 
+from ..runtime import Scope, State
 from ..defs import RuntimeConfiguration
 from ..specs import Spec, SpecFromBExp, SpecUnOp, SpecBinOp, SpecQuant, Domain, DomainIdent, DomainInterval, DomainRange, DomainType, DomainValues, DomainVar
 from ..spec_parser import ABoundVar
@@ -17,58 +18,89 @@ class QuantifierType(Enum):
 
 class Z3Mapper():
 
-    var_map : Dict[str, z3types.Sort]
-    bound_vars_map : Dict[str, z3types.ExprRef] = dict()
+    free_var_map : Dict[str, z3types.Sort]
+    bound_var_map : Dict[str, z3types.ExprRef] = dict()
 
     
-    def __init__(self, config : RuntimeConfiguration, solver : Solver):
-        self.var_map = dict()
+    def __init__(self, config : RuntimeConfiguration, solver : Solver, lexical_depth: int = 0):
+        self.free_var_map = dict()
         self.scope = config.scope
         self.state = config.state
+        self.lexical_depth = lexical_depth
 
-        # map the scope
-        # TODO: does this also handle parent scopes and states?
+        # Note: this algorithm needs the state and scope to have the exact same depth.
+        # This is ensured by the _fresh_runtime() method in the interpreter.
+        if self.scope.depth != self.state.depth:
+            raise VerifierRuntimeError(f"Scope depth and state depth mismatch")
 
-        for var, vartype in self.scope.items():
+        # map the scope and its parent scopes
+        self.map_scope(self.scope)
+
+        # map the state and its parent scopes
+        self.map_state(self.state, self.scope, solver)
+
+
+    ######### Configuration Mapping #########    
+
+    def map_scope(self, scope: Scope) -> Dict[str, z3types.ExprRef]:
+        for var, vartype in scope.items():
             if vartype is None:
                 continue
+            
+            var_z3_name = Z3Mapper.get_z3_var_name(var, scope.scope_id)
             if vartype.kind == "INT":
-                self.var_map[var] = Int(var)
+                self.free_var_map[var_z3_name] = Int(var_z3_name)
             elif vartype.kind == "FLOAT":
-                self.var_map[var] = Real(var)
+                self.free_var_map[var_z3_name] = Real(var_z3_name)
             elif vartype.kind == "LIST":
                 if vartype.elem_kind == "INT":
-                    self.var_map[var] = Array(var, IntSort(), IntSort())
+                    self.free_var_map[var_z3_name] = Array(var_z3_name, IntSort(), IntSort())
                 elif vartype.elem_kind == "FLOAT":
-                    self.var_map[var] = Array(var, IntSort(), RealSort())
+                    self.free_var_map[var_z3_name] = Array(var_z3_name, IntSort(), RealSort())
                 else:
                     raise VerifierRuntimeError(f"Unsupported list element type: {vartype.elem_kind}")
             else:
                 raise VerifierRuntimeError(f"Unsupported variable type: {vartype.kind}")
 
-        for var, value in self.state.items():
-            if var not in self.scope:
+        # recurse to parent scopes
+        if scope.parent is not None:
+            self.map_scope(scope.parent)
+
+    def map_state(self, state : State, scope: Scope, solver : Solver) -> None:
+        for var, value in state.items():
+            if var not in scope:
                 raise VerifierRuntimeError(f"Variable {var} not found in scope")
             try:
-                vartype = self.scope[var]
+                vartype = scope[var]
                 if vartype is None:
                     continue
+                var_z3_name = Z3Mapper.get_z3_var_name(var, scope.scope_id)
                 if vartype.kind == "LIST":
                     if len(value) != vartype.size:
                         raise VerifierRuntimeError(f"Variable {var} has size mismatch")
                     for i in range(vartype.size):
-                        solver.add(self.var_map[var][i] == value[i])
+                        solver.add(self.free_var_map[var_z3_name][i] == value[i])
                 else: # INT or FLOAT
-                    solver.add(self.var_map[var] == value)
+                    solver.add(self.free_var_map[var_z3_name] == value)
             except Z3Exception as e:
                 if "sort mismatch" in str(e):
                     raise VerifierRuntimeError(f"Variable {var} has sort mismatch")
                 else:
                     raise
+        
+        if scope.parent is not None and state.parent is not None:
+            self.map_state(state.parent, scope.parent, solver)
+        elif scope.parent is None and state.parent is not None:
+            raise VerifierRuntimeError(f"State has parent but scope does not")
+        elif scope.parent is not None and state.parent is None:
+            raise VerifierRuntimeError(f"Scope has parent but state does not")
+                  
 
-        self.temp_count = 0
     
-    def map_FOL(self , spec: Spec) -> z3types.ExprRef:
+    ######### Specification Mapping #########    
+
+    
+    def map_FOL(self, spec: Spec) -> z3types.ExprRef:
         if isinstance(spec, SpecFromBExp):
             return self.map_FOL_bexp(spec)
         elif isinstance(spec, SpecUnOp):
@@ -79,6 +111,19 @@ class Z3Mapper():
             return self.map_FOL_quant(spec)
         raise VerifierRuntimeError(f"Unsupported FOL specification")
 
+    def get_lexical_owner_scope_id(self, name: str) -> int:
+        # lexical_depth ensures we don't accidentally resolve variables from inner scopes
+        # that were not visible when/where the specification was defined (vertical isolation).
+        lex_scope = self.scope
+        while lex_scope is not None and lex_scope.depth > self.lexical_depth:
+            lex_scope = lex_scope.parent
+        if lex_scope is None:
+            raise VerifierRuntimeError(f"Lexical depth {self.lexical_depth} not found")
+        owner = lex_scope.find_owner(name)
+        if owner is None:
+            raise VerifierRuntimeError(f"Variable {name} not found in lexical scope")
+        return owner.scope_id
+
     def map_FOL_aexp(self, aexp: AExp) -> z3types.ExprRef :
         if isinstance(aexp, IntLit):
             return IntVal(aexp.value)
@@ -87,21 +132,23 @@ class Z3Mapper():
         elif isinstance(aexp, ListLit):
             return self.map_FOL_listlit(aexp)
         elif isinstance(aexp, AVar):
-            if aexp.name not in self.var_map:
-                raise VerifierRuntimeError(f"Free variable {aexp.name} not found in scope")
-            return self.var_map[aexp.name]
+            var_z3_name = Z3Mapper.get_z3_var_name(aexp.name, self.get_lexical_owner_scope_id(aexp.name))
+            if var_z3_name not in self.free_var_map:
+                raise VerifierRuntimeError(f"Free variable {aexp.name} (Z3 name: {var_z3_name}) not mapped")
+            return self.free_var_map[var_z3_name]
         elif isinstance(aexp, ABoundVar):
-            if aexp.name not in self.bound_vars_map:
+            if aexp.name not in self.bound_var_map:
                 raise VerifierRuntimeError(f"Bound variable &{aexp.name} not found in scope")
-            return self.bound_vars_map[aexp.name]
+            return self.bound_var_map[aexp.name]
         elif isinstance(aexp, ALen):
-            if aexp.name not in self.var_map:
-                raise VerifierRuntimeError(f"List variable {aexp.name} not found in scope")
-            if is_array(self.var_map[aexp.name]): # LIST
-                len_name = Z3Mapper.get_length(aexp.name)
-                if len_name not in self.var_map:
-                    raise VerifierRuntimeError(f"Length shadow variable {len_name} of the list {aexp.name} not found in scope")
-                return self.var_map[len_name]
+            var_z3_name = Z3Mapper.get_z3_var_name(aexp.name, self.get_lexical_owner_scope_id(aexp.name))
+            if var_z3_name not in self.free_var_map:
+                raise VerifierRuntimeError(f"List variable {aexp.name} (Z3 name: {var_z3_name}) not mapped")
+            if is_array(self.free_var_map[var_z3_name]): # LIST
+                len_z3_name = self.get_length(aexp.name)
+                if len_z3_name not in self.free_var_map:
+                    raise VerifierRuntimeError(f"Length shadow variable {aexp.name}_len_1 of the list {aexp.name} (Z3 name: {var_z3_name}) not mapped")
+                return self.free_var_map[len_z3_name]
             else: # INT or FLOAT
                 return IntVal(0)
         elif isinstance(aexp, AIndex):
@@ -159,23 +206,24 @@ class Z3Mapper():
             indices.append(self.map_FOL_aexp(cur.index))
             cur = cur.base
         base_name = cur.name
-        if base_name not in self.var_map:
-            raise VerifierRuntimeError(f"Variable {base_name} not found in scope")
+        base_z3_name = Z3Mapper.get_z3_var_name(base_name, self.get_lexical_owner_scope_id(base_name))
+        if base_z3_name not in self.free_var_map:
+            raise VerifierRuntimeError(f"Variable {base_name} (Z3 name: {base_z3_name}) not mapped")
 
         indices.reverse() # collect indices
         flat_index: z3types.ExprRef | None = None
         for pos, index_expr in enumerate(indices):
             term = index_expr
             for dim in range(pos + 2, self.get_list_dimension(base_name) + 1):
-                len_name = Z3Mapper.get_dimension_length(base_name, dim)
-                if len_name not in self.var_map:
+                len_name = self.get_dimension_length(base_name, dim)
+                if len_name not in self.free_var_map:
                     raise VerifierRuntimeError(
-                        f"Variable {len_name} not found in scope"
+                        f"Variable {base_name}_len_{dim} not found in scope"
                     )
-                term = term * self.var_map[len_name]
+                term = term * self.free_var_map[len_name]
             flat_index = term if flat_index is None else flat_index + term
 
-        return self.var_map[base_name][flat_index]
+        return self.free_var_map[base_z3_name][flat_index]
 
     def map_FOL_bexp(self, spec: SpecFromBExp) -> z3types.ExprRef:
         return self._map_bexp(spec.bexp)
@@ -241,12 +289,11 @@ class Z3Mapper():
 
     
     def map_quantification(self, spec : SpecQuant, quantifier : QuantifierType) -> z3types.ExprRef:
-        if spec.var in self.bound_vars_map:
+        if spec.var in self.bound_var_map:
             raise VerifierRuntimeError(f"Variable {spec.var} is already bound by a quantifier")
         
         domain : Domain = spec.domain
         bound_var = spec.var
-
 
         # uses Z3 quantifier
         if isinstance(domain, DomainType):
@@ -258,16 +305,16 @@ class Z3Mapper():
                 bound_var_z3 = Real("&" + bound_var)
             else:
                 raise VerifierRuntimeError(f"Unsupported domain type: {domain}")
-            self.bound_vars_map[bound_var] = bound_var_z3
+            self.bound_var_map[bound_var] = bound_var_z3
             if quantifier == QuantifierType.Forall:
                 result = ForAll(bound_var_z3, self.map_FOL(spec.body))
             else: # QuantifierType.Exists
                 result = Exists(bound_var_z3, self.map_FOL(spec.body))
-            del self.bound_vars_map[bound_var]
+            del self.bound_var_map[bound_var]
             return result
         elif isinstance(domain, DomainRange):
             bound_var_z3 = Int("&" + bound_var)
-            self.bound_vars_map[bound_var] = bound_var_z3
+            self.bound_var_map[bound_var] = bound_var_z3
             lo = self.map_FOL_aexp(domain.lo)
             hi = self.map_FOL_aexp(domain.hi)
             domain_z3 = And(lo <= bound_var_z3, bound_var_z3 <= hi)
@@ -275,11 +322,11 @@ class Z3Mapper():
                 result = ForAll(bound_var_z3, Implies(domain_z3, self.map_FOL(spec.body)))
             else: # QuantifierType.Exists
                 result = Exists(bound_var_z3, And(domain_z3, self.map_FOL(spec.body)))
-            del self.bound_vars_map[bound_var]
+            del self.bound_var_map[bound_var]
             return result
         elif isinstance(domain, DomainInterval):
             bound_var_z3 = Real("&" + bound_var)
-            self.bound_vars_map[bound_var] = bound_var_z3
+            self.bound_var_map[bound_var] = bound_var_z3
             lo = self.map_FOL_aexp(domain.lo)
             hi = self.map_FOL_aexp(domain.hi)
             if domain.left_closed:
@@ -295,30 +342,42 @@ class Z3Mapper():
                 result = ForAll(bound_var_z3, Implies(domain_z3, self.map_FOL(spec.body)))
             else: # QuantifierType.Exists
                 result = Exists(bound_var_z3, And(domain_z3, self.map_FOL(spec.body)))
-            del self.bound_vars_map[bound_var]
+            del self.bound_var_map[bound_var]
             return result
         else: # uses finite_connector over finite domain
             result_list = list()
             if isinstance(domain, DomainIdent):
-                if not is_array(self.var_map[domain.name]):
+                domain_z3_name = Z3Mapper.get_z3_var_name(domain.name, self.get_lexical_owner_scope_id(domain.name))
+                if domain_z3_name not in self.free_var_map:
+                    raise VerifierRuntimeError(f"Variable {domain.name} (Z3 name: {domain_z3_name}) not mapped")
+                if not is_array(self.free_var_map[domain_z3_name]):
                     raise VerifierRuntimeError(f"Variable {domain.name} is not a list")
                 # TODO: consider multi-dim lists
-                for i in range(self.state[Z3Mapper.get_dimension_length(domain.name, 1)]):
-                    self.bound_vars_map[bound_var] = self.map_FOL_aexp(AIndex(AVar(domain.name), IntLit(i)))
+                for i in range(self.state[f"_{domain.name}_len_1"]):
+                    self.bound_var_map[bound_var] = self.map_FOL_aexp(AIndex(AVar(domain.name), IntLit(i)))
                     result_list.append(self.map_FOL(spec.body))     
             elif isinstance(domain, DomainValues):
                 for val in domain.items:
-                    self.bound_vars_map[bound_var] = self.map_FOL_aexp(val)
+                    self.bound_var_map[bound_var] = self.map_FOL_aexp(val)
                     result_list.append(self.map_FOL(spec.body))     
             elif isinstance(domain, DomainVar):
-                for var, vartype in self.scope.items():
+                lex_scope = self.scope
+                while lex_scope is not None and lex_scope.depth > self.lexical_depth:
+                    lex_scope = lex_scope.parent
+                if lex_scope is None:
+                    raise VerifierRuntimeError(f"Lexical depth {self.lexical_depth} not found")
+                for var, vartype in lex_scope.items():
                     if vartype == domain.elem:
-                        self.bound_vars_map[bound_var] = self.var_map[var]
-                        result_list.append(self.map_FOL(spec.body))                  
+                        owner = lex_scope.find_owner(var)
+                        if owner is not None:
+                            self.bound_var_map[bound_var] = self.free_var_map[Z3Mapper.get_z3_var_name(var, owner.scope_id)]
+                            result_list.append(self.map_FOL(spec.body))   
+                        else:
+                            raise VerifierRuntimeError(f"Variable {var} not found in scope")               
             else:
                 raise VerifierRuntimeError(f"Unsupported domain type: {domain}")
                 
-            del self.bound_vars_map[bound_var]
+            del self.bound_var_map[bound_var]
             if quantifier == QuantifierType.Forall:
                 return And(result_list)
             else: # QuantifierType.Exists
@@ -327,29 +386,28 @@ class Z3Mapper():
 
                 
     def get_list_dimension(self, name: str) -> int:
-        if name not in self.var_map or self.var_map[name] is None:
+        owner = self.scope.find_owner(name)
+        if owner is None:
             raise VerifierRuntimeError(f"Variable {name} not found in scope")
-        if not is_array(self.var_map[name]):
+        name_z3 = Z3Mapper.get_z3_var_name(name, owner.scope_id)
+        if name_z3 not in self.free_var_map or self.free_var_map[name_z3] is None:
+            raise VerifierRuntimeError(f"Variable {name} not found in scope")
+        if not is_array(self.free_var_map[name_z3]):
             raise VerifierRuntimeError(f"Variable {name} is not a list")
 
         dim = 0
-        while Z3Mapper.get_dimension_length(name, dim + 1) in self.var_map:
+        while self.get_dimension_length(name, dim + 1) in self.free_var_map:
             dim += 1
         return dim if dim > 0 else 1
 
-    @staticmethod
-    def get_length(var_name: str) -> str:
-        return Z3Mapper.get_dimension_length(var_name, 1)
+    def get_length(self, var_name: str) -> str:
+        return self.get_dimension_length(var_name, 1)
+
+    def get_dimension_length(self, var_name: str, dim: int) -> str:
+        return Z3Mapper.get_z3_var_name(f"_{var_name}_len_{dim}", self.get_lexical_owner_scope_id(var_name))
 
     @staticmethod
-    def get_dimension_length(var_name: str, dim: int) -> str:
-        return f"_{var_name}_len_{dim}"
-            
-        
-        
-            
-            
-
-                
-            
-        
+    def get_z3_var_name(var_name: str, scope_id : int) -> str:
+        # scope_id gives every unique scope block its own globally unique Z3 namespace,
+        # ensuring independent history tracking for horizontally isolated blocks.
+        return f"_s{scope_id}_{var_name}"

--- a/src/selveri/SelVerifier/mapper.py
+++ b/src/selveri/SelVerifier/mapper.py
@@ -111,18 +111,32 @@ class Z3Mapper():
             return self.map_FOL_quant(spec)
         raise VerifierRuntimeError(f"Unsupported FOL specification")
 
-    def get_lexical_owner_scope_id(self, name: str) -> int:
-        # lexical_depth ensures we don't accidentally resolve variables from inner scopes
-        # that were not visible when/where the specification was defined (vertical isolation).
+    def _get_lexical_scope(self) -> Scope:
+        """
+        Traverses up the scope hierarchy to find the scope matching the current lexical depth.
+        This ensures we don't accidentally resolve variables from inner scopes that were not visible
+        when/where the specification was defined (vertical isolation).
+        """
         lex_scope = self.scope
         while lex_scope is not None and lex_scope.depth > self.lexical_depth:
             lex_scope = lex_scope.parent
         if lex_scope is None:
             raise VerifierRuntimeError(f"Lexical depth {self.lexical_depth} not found")
+        return lex_scope
+
+    def get_lexical_owner_scope_id(self, name: str) -> int:
+        lex_scope = self._get_lexical_scope()
         owner = lex_scope.find_owner(name)
         if owner is None:
             raise VerifierRuntimeError(f"Variable {name} not found in lexical scope")
         return owner.scope_id
+
+    def get_scoped_z3_var_name(self, name: str) -> str:
+        """
+        Resolves the lexical owner scope of a given variable name and returns its fully qualified
+        Z3 variable name, ensuring accurate mapping to the correct isolated execution context.
+        """
+        return Z3Mapper.get_z3_var_name(name, self.get_lexical_owner_scope_id(name))
 
     def map_FOL_aexp(self, aexp: AExp) -> z3types.ExprRef :
         if isinstance(aexp, IntLit):
@@ -132,7 +146,7 @@ class Z3Mapper():
         elif isinstance(aexp, ListLit):
             return self.map_FOL_listlit(aexp)
         elif isinstance(aexp, AVar):
-            var_z3_name = Z3Mapper.get_z3_var_name(aexp.name, self.get_lexical_owner_scope_id(aexp.name))
+            var_z3_name = self.get_scoped_z3_var_name(aexp.name)
             if var_z3_name not in self.free_var_map:
                 raise VerifierRuntimeError(f"Free variable {aexp.name} (Z3 name: {var_z3_name}) not mapped")
             return self.free_var_map[var_z3_name]
@@ -141,7 +155,7 @@ class Z3Mapper():
                 raise VerifierRuntimeError(f"Bound variable &{aexp.name} not found in scope")
             return self.bound_var_map[aexp.name]
         elif isinstance(aexp, ALen):
-            var_z3_name = Z3Mapper.get_z3_var_name(aexp.name, self.get_lexical_owner_scope_id(aexp.name))
+            var_z3_name = self.get_scoped_z3_var_name(aexp.name)
             if var_z3_name not in self.free_var_map:
                 raise VerifierRuntimeError(f"List variable {aexp.name} (Z3 name: {var_z3_name}) not mapped")
             if is_array(self.free_var_map[var_z3_name]): # LIST
@@ -206,7 +220,7 @@ class Z3Mapper():
             indices.append(self.map_FOL_aexp(cur.index))
             cur = cur.base
         base_name = cur.name
-        base_z3_name = Z3Mapper.get_z3_var_name(base_name, self.get_lexical_owner_scope_id(base_name))
+        base_z3_name = self.get_scoped_z3_var_name(base_name)
         if base_z3_name not in self.free_var_map:
             raise VerifierRuntimeError(f"Variable {base_name} (Z3 name: {base_z3_name}) not mapped")
 
@@ -347,7 +361,7 @@ class Z3Mapper():
         else: # uses finite_connector over finite domain
             result_list = list()
             if isinstance(domain, DomainIdent):
-                domain_z3_name = Z3Mapper.get_z3_var_name(domain.name, self.get_lexical_owner_scope_id(domain.name))
+                domain_z3_name = self.get_scoped_z3_var_name(domain.name)
                 if domain_z3_name not in self.free_var_map:
                     raise VerifierRuntimeError(f"Variable {domain.name} (Z3 name: {domain_z3_name}) not mapped")
                 if not is_array(self.free_var_map[domain_z3_name]):
@@ -361,11 +375,7 @@ class Z3Mapper():
                     self.bound_var_map[bound_var] = self.map_FOL_aexp(val)
                     result_list.append(self.map_FOL(spec.body))     
             elif isinstance(domain, DomainVar):
-                lex_scope = self.scope
-                while lex_scope is not None and lex_scope.depth > self.lexical_depth:
-                    lex_scope = lex_scope.parent
-                if lex_scope is None:
-                    raise VerifierRuntimeError(f"Lexical depth {self.lexical_depth} not found")
+                lex_scope = self._get_lexical_scope()
                 for var, vartype in lex_scope.items():
                     if vartype == domain.elem:
                         owner = lex_scope.find_owner(var)

--- a/src/selveri/SelVerifier/verifier.py
+++ b/src/selveri/SelVerifier/verifier.py
@@ -22,6 +22,9 @@ class VerificationEngine():
         self.specs_by_id: Dict[int, ParsedSpec] = dict()
         self.prepared = False
 
+
+    ################# Spec Compilation #################
+
     # the verifier owns spec parsing and caches parsed ASTs before execution starts.
     def prepare_program(
         self,
@@ -83,7 +86,9 @@ class VerificationEngine():
         self.on_veri(parsed_spec.ast, snapshot) # call the on_veri callback
         return parsed_spec
 
-    def on_program_start(self) -> None: ...
+    ################# ###########################    
+    ################# Verifying #################
+    #############################################        
 
     def on_step(self, snapshot: RuntimeConfiguration) -> None:
         # TODO: investigate the memory management here
@@ -108,7 +113,9 @@ class VerificationEngine():
             return self.verify_past_LTL(spec, self.last_step - 1, start_step, lexical_depth)
         else: # spec.type == SpecType.fLTL:
             return self.verify_future_LTL(spec, snapshot, snapshot.scope.depth)
-        
+    
+    ################# FOL Verification #################
+
     def verify_FOL(self, spec: Spec, snapshot: RuntimeConfiguration, lexical_depth: int) -> bool:
         solver = Solver()
         mapper = Z3Mapper(snapshot, solver, lexical_depth)
@@ -120,6 +127,9 @@ class VerificationEngine():
             # TODO: consider giving a counter-example, using the model
             # model : ModelRef = solver.model()
             return False
+
+
+    ################# pLTL Verification #################
 
     def verify_past_LTL(self, spec: Spec, step : int, start_step : int, lexical_depth: int = 0) -> bool:
         if spec in self.pltl_memo[step]: # memoization for efficiency
@@ -172,7 +182,6 @@ class VerificationEngine():
     def pltl_deduce_inital_step(self, spec: Spec, lexical_scope: Any) -> int:
         variables = self._spec_get_free_variables(spec, set())
         inital_step = 0
-        from .mapper import Z3Mapper
         for var in variables:
             owner = lexical_scope.find_owner(var)
             if owner is None:
@@ -186,7 +195,21 @@ class VerificationEngine():
                 raise VerificationError(f"Variable {var} has no initialization or declaration step")
         return inital_step
 
-    
+    def register_declaration(self, name: str, scope_id: int) -> None:
+        """Records the step when a variable is declared in a specific scope."""
+        name_z3 = Z3Mapper.get_z3_var_name(name, scope_id)
+        if name_z3 not in self.declaration_steps:
+            self.declaration_steps[name_z3] = self.last_step
+
+    def register_initial_assignment(self, name: str, scope: Any) -> None:
+        """Records the step when a variable is first initialized/assigned, removing it from declarations."""
+        owner = scope.find_owner(name)
+        scope_id = owner.scope_id if owner else scope.scope_id
+        name_z3 = Z3Mapper.get_z3_var_name(name, scope_id)
+        if name_z3 not in self.initialization_steps:
+            self.initialization_steps[name_z3] = self.last_step
+            self.declaration_steps.pop(name_z3, None)
+
     def _spec_get_free_variables(self, spec: Spec, variables: set[str]) -> set[str]:
         if isinstance(spec, SpecFromBExp):
             self._bexp_get_free_variables(spec.bexp, variables)
@@ -251,6 +274,7 @@ class VerificationEngine():
         # DomainType, DomainVar — no runtime variables
 
 
-    
+    ################# fLTL Verification #################
+
     def verify_future_LTL(self, spec: Spec, snapshot: RuntimeConfiguration) -> bool: ...
     def on_program_end(self) -> None: ...

--- a/src/selveri/SelVerifier/verifier.py
+++ b/src/selveri/SelVerifier/verifier.py
@@ -98,18 +98,21 @@ class VerificationEngine():
             raise VerificationError(f"Specification '{spec}' failed")
 
     def verify(self, spec: Spec, snapshot : RuntimeConfiguration, start_step : Optional[int] = None) -> bool: 
+        # lexical_depth captures the depth at which the spec is defined. This is passed to 
+        # historical evaluations to ensure we don't resolve inner-scope variables that the spec shouldn't see.
+        lexical_depth = snapshot.scope.depth
         if spec.type == SpecType.FOL:
-            return self.verify_FOL(spec, snapshot)
+            return self.verify_FOL(spec, snapshot, lexical_depth)
         elif spec.type == SpecType.pLTL:
             if start_step is None:
-                start_step = self.pltl_deduce_inital_step(spec)
-            return self.verify_past_LTL(spec, self.last_step - 1, start_step)
+                start_step = self.pltl_deduce_inital_step(spec, snapshot.scope)
+            return self.verify_past_LTL(spec, self.last_step - 1, start_step, lexical_depth)
         else: # spec.type == SpecType.fLTL:
-            return self.verify_future_LTL(spec, snapshot)
+            return self.verify_future_LTL(spec, snapshot, snapshot.scope.depth)
         
-    def verify_FOL(self, spec: Spec, snapshot: RuntimeConfiguration) -> bool:
+    def verify_FOL(self, spec: Spec, snapshot: RuntimeConfiguration, lexical_depth: int) -> bool:
         solver = Solver()
-        mapper = Z3Mapper(snapshot, solver)
+        mapper = Z3Mapper(snapshot, solver, lexical_depth)
         negated_assumption = simplify(Not(mapper.map_FOL(spec)))
         result = solver.check(negated_assumption)
         if result == unsat:
@@ -120,46 +123,46 @@ class VerificationEngine():
             return False
 
     # TODO: check the base cases
-    def verify_past_LTL(self, spec: Spec, step : int, start_step : int) -> bool:
+    def verify_past_LTL(self, spec: Spec, step : int, start_step : int, lexical_depth: int = 0) -> bool:
         if spec in self.pltl_memo[step]: # memoization for efficiency
             return self.pltl_memo[step][spec]
         
         if spec.type == SpecType.FOL:
-            result = self.verify_FOL(spec, self.history[step])
+            result = self.verify_FOL(spec, self.history[step], lexical_depth)
         
         elif isinstance(spec, SpecUnOp):
             if spec.op == "!":
-                result = not self.verify_past_LTL(spec.rhs, step, start_step)
+                result = not self.verify_past_LTL(spec.rhs, step, start_step, lexical_depth)
             elif spec.op == "Previously":
                 if step == start_step:
                     result = False
                 else:
-                    result = self.verify_past_LTL(spec.rhs, step - 1, start_step)
+                    result = self.verify_past_LTL(spec.rhs, step - 1, start_step, lexical_depth)
             elif spec.op == "Once":
                 if step == start_step:
-                    result = self.verify_past_LTL(spec.rhs, step, start_step)
+                    result = self.verify_past_LTL(spec.rhs, step, start_step, lexical_depth)
                 else:
-                    result = self.verify_past_LTL(spec.rhs, step, start_step) or self.verify_past_LTL(spec, step - 1, start_step)
+                    result = self.verify_past_LTL(spec.rhs, step, start_step, lexical_depth) or self.verify_past_LTL(spec, step - 1, start_step, lexical_depth)
             elif spec.op == "Historically":
                 if step == start_step:
-                    result = self.verify_past_LTL(spec.rhs, step, start_step)
+                    result = self.verify_past_LTL(spec.rhs, step, start_step, lexical_depth)
                 else:
-                    result = self.verify_past_LTL(spec.rhs, step, start_step) and self.verify_past_LTL(spec, step - 1, start_step)
+                    result = self.verify_past_LTL(spec.rhs, step, start_step, lexical_depth) and self.verify_past_LTL(spec, step - 1, start_step, lexical_depth)
 
         elif isinstance(spec, SpecBinOp):
             if spec.op == "&&":
-                result = self.verify_past_LTL(spec.left, step, start_step) and self.verify_past_LTL(spec.right, step, start_step)
+                result = self.verify_past_LTL(spec.left, step, start_step, lexical_depth) and self.verify_past_LTL(spec.right, step, start_step, lexical_depth)
             elif spec.op == "||":
-                result = self.verify_past_LTL(spec.left, step, start_step) or self.verify_past_LTL(spec.right, step, start_step)
+                result = self.verify_past_LTL(spec.left, step, start_step, lexical_depth) or self.verify_past_LTL(spec.right, step, start_step, lexical_depth)
             elif spec.op == "=>":
-                result = (not self.verify_past_LTL(spec.left, step, start_step)) or self.verify_past_LTL(spec.right, step, start_step)
+                result = (not self.verify_past_LTL(spec.left, step, start_step, lexical_depth)) or self.verify_past_LTL(spec.right, step, start_step, lexical_depth)
             elif spec.op == "Since":
-                right = self.verify_past_LTL(spec.right, step, start_step)
+                right = self.verify_past_LTL(spec.right, step, start_step, lexical_depth)
                 if step == start_step:
                     result = right
                 else:
-                    left = self.verify_past_LTL(spec.left, step, start_step)
-                    result = right or (left and self.verify_past_LTL(spec, step - 1, start_step))
+                    left = self.verify_past_LTL(spec.left, step, start_step, lexical_depth)
+                    result = right or (left and self.verify_past_LTL(spec, step - 1, start_step, lexical_depth))
         
         else:
             raise VerificationError(f"Unexpected specification type for pLTL: {spec.type}")
@@ -168,14 +171,19 @@ class VerificationEngine():
         return result
 
 
-    def pltl_deduce_inital_step(self, spec: Spec) -> int:
+    def pltl_deduce_inital_step(self, spec: Spec, lexical_scope: Any) -> int:
         variables = self._spec_get_free_variables(spec, set())
         inital_step = 0
+        from .mapper import Z3Mapper
         for var in variables:
-            if var in self.initialization_steps:
-                inital_step = max(inital_step, self.initialization_steps[var])
-            elif var in self.declaration_steps:
-                inital_step = max(inital_step, self.declaration_steps[var])
+            owner = lexical_scope.find_owner(var)
+            if owner is None:
+                raise VerificationError(f"Variable {var} not found in scope")
+            var_z3_name = Z3Mapper.get_z3_var_name(var, owner.scope_id)
+            if var_z3_name in self.initialization_steps:
+                inital_step = max(inital_step, self.initialization_steps[var_z3_name])
+            elif var_z3_name in self.declaration_steps:
+                inital_step = max(inital_step, self.declaration_steps[var_z3_name])
             else:
                 raise VerificationError(f"Variable {var} has no initialization or declaration step")
         return inital_step

--- a/src/selveri/SelVerifier/verifier.py
+++ b/src/selveri/SelVerifier/verifier.py
@@ -14,8 +14,7 @@ from .mapper import Z3Mapper
 class VerificationEngine():
     def __init__(self):
         self.last_step = 0
-        self.declaration_steps: Dict[str, int] = dict() # stores the declaration steps of variables
-        # TODO: initialization_steps needs to support nested scopes/states
+        self.declaration_steps: Dict[str, int] = dict() # stores the declaration steps of variable
         self.initialization_steps : Dict[str, int] = dict() # stores the initial assignment steps of variables
         self.history: list[RuntimeConfiguration] = list()
         self.pltl_memo : Dict[int, Dict[Spec, bool]] = dict() # for pLTL verification memoization
@@ -122,7 +121,6 @@ class VerificationEngine():
             # model : ModelRef = solver.model()
             return False
 
-    # TODO: check the base cases
     def verify_past_LTL(self, spec: Spec, step : int, start_step : int, lexical_depth: int = 0) -> bool:
         if spec in self.pltl_memo[step]: # memoization for efficiency
             return self.pltl_memo[step][spec]

--- a/src/selveri/defs.py
+++ b/src/selveri/defs.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any
 
-from .runtime import DeclType
+from .runtime import Scope, State
 
 
 class AExp: pass
@@ -12,8 +12,8 @@ class Stmt: pass
 
 @dataclass(frozen=True)
 class RuntimeConfiguration:
-    state: Dict[str, Any]
-    scope: Dict[str, Optional[DeclType]]
+    state: State
+    scope: Scope
     
 @dataclass(frozen=True)
 class Formula:

--- a/src/selveri/interpreter.py
+++ b/src/selveri/interpreter.py
@@ -8,10 +8,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
+from .defs import RuntimeConfiguration
 from .errors import IRRuntimeError, IRParseError
 from .compiler import IRInstr
-from .runtime import DeclType, RuntimeScope, _UNSET
-from .SelVerifier.verifier import RuntimeConfiguration, VerificationEngine
+from .runtime import DeclType, Scope, State, _UNSET
+from .SelVerifier.verifier import VerificationEngine
 
 
 @dataclass
@@ -27,7 +28,7 @@ class ExecutionResult:
 @dataclass(frozen=True)
 class CallFrame:
     return_pc: int
-    scopes: Tuple[RuntimeScope, ...]
+    runtime: RuntimeConfiguration
     function_name: Optional[str] = None
     return_type: Optional[DeclType] = None
 
@@ -313,10 +314,8 @@ class SelVerIRInterpreter:
         self.label_to_index: Dict[int, int] = {}
         self.functions: Dict[str, FunctionEntry] = {}
 
-        self.state: Dict[str, float | int | List[float | int]] = {}
-        self.scope: Dict[str, DeclType] = {}
         self.stack: List[Union[int, float]] = []
-        self.scopes: List[RuntimeScope] = []
+        self.runtime: RuntimeConfiguration = self._fresh_runtime()
         self.call_stack: List[CallFrame] = []
 
         self.pc: int = 0
@@ -341,11 +340,10 @@ class SelVerIRInterpreter:
 
     def reset_runtime(self) -> None:
         self.stack = [] # clear the stack
-        self.scopes = [self._fresh_scope()]
+        self.runtime = self._fresh_runtime()
         self.call_stack = []
         self.pc = 0 # reset the program counter
         self.steps = 0 # reset the steps
-        self._refresh_public_views()
 
     # ---------- stack ----------
     def _push(self, value: Any) -> None:
@@ -362,54 +360,47 @@ class SelVerIRInterpreter:
         return left, right
 
     # ---------- lookup ----------
-    def _fresh_scope(self) -> RuntimeScope:
-        return RuntimeScope(values={"retvar": _UNSET}, types={"retvar": None})
+    def _fresh_scope(self, parent: Optional[Scope] = None) -> Scope:
+        return Scope(types={"retvar": None}, parent=parent)
 
-    def _refresh_public_views(self) -> None:
-        visible_state: Dict[str, Any] = {}
-        visible_types: Dict[str, DeclType] = {}
+    def _fresh_state(self, parent: Optional[State] = None) -> State:
+        return State(values={"retvar": _UNSET}, parent=parent)
 
-        for scope in self.scopes:
-            for name, value in scope.values.items():
-                if value is not _UNSET:
-                    visible_state[name] = value
-            for name, decl_type in scope.types.items():
-                if decl_type is not None:
-                    visible_types[name] = decl_type
+    def _fresh_runtime(
+        self,
+        *,
+        state_parent: Optional[State] = None,
+        scope_parent: Optional[Scope] = None,
+    ) -> RuntimeConfiguration:
+        return RuntimeConfiguration(
+            state=self._fresh_state(parent=state_parent),
+            scope=self._fresh_scope(parent=scope_parent),
+        )
 
-        self.state = visible_state
-        self.scope = visible_types
+    def _refresh_public_views(self) -> Tuple[Dict[str, Any], Dict[str, DeclType]]:
+        return self.runtime.state.visible_values(), self.runtime.scope.visible_types()
 
-    def _find_scope_with_type(self, name: str) -> Optional[RuntimeScope]:
-        for scope in reversed(self.scopes):
-            if name in scope.types:
-                return scope
-        return None
+    def _find_scope_with_type(self, name: str) -> Optional[Scope]:
+        return self.runtime.scope.find_owner(name)
 
-    def _find_scope_with_value(self, name: str) -> Optional[RuntimeScope]:
-        for scope in reversed(self.scopes):
-            if name in scope.values:
-                return scope
-        return None
+    def _find_state_with_value(self, name: str) -> Optional[State]:
+        return self.runtime.state.find_owner(name)
 
     def _require_declared(self, name: str) -> None:
-        if self._find_scope_with_type(name) is None:
+        if name not in self.runtime.scope:
             raise IRRuntimeError(f"Undeclared variable: {name}")
 
     def _get_decl_type(self, name: str) -> DeclType:
         self._require_declared(name)
-        scope = self._find_scope_with_type(name)
-        assert scope is not None
-        decl_type = scope.types[name]
+        decl_type = self.runtime.scope[name]
         if decl_type is None:
             raise IRRuntimeError(f"{name} has no runtime type.")
         return decl_type
 
     def _get_value(self, name: str) -> Any:
-        scope = self._find_scope_with_value(name)
-        if scope is None:
+        if name not in self.runtime.state:
             raise IRRuntimeError(f"Undeclared variable: {name}")
-        value = scope.values[name]
+        value = self.runtime.state[name]
         if value is _UNSET:
             raise IRRuntimeError(f"Uninitialized variable: {name}")
         return value
@@ -418,14 +409,17 @@ class SelVerIRInterpreter:
         scope = self._find_scope_with_type(name)
         if scope is None:
             raise IRRuntimeError(f"Undeclared variable: {name}")
-        scope.values[name] = value
+        state = self._find_state_with_value(name)
+        if state is None:
+            raise IRRuntimeError(f"Undeclared variable: {name}")
+        state.values[name] = value
 
     def _declare(self, name: str, decl_type: DeclType, value: Any) -> None:
-        scope = self.scopes[-1]
+        scope = self.runtime.scope
         if name in scope.types and name != "retvar":
             raise IRRuntimeError(f"{name} has already been declared.")
-        scope.types[name] = decl_type
-        scope.values[name] = value
+        scope[name] = decl_type
+        self.runtime.state[name] = value
 
     def _infer_decl_type_from_value(self, value: Any) -> DeclType:
         if isinstance(value, bool):
@@ -442,14 +436,15 @@ class SelVerIRInterpreter:
         raise IRRuntimeError(f"Unsupported runtime value: {value!r}")
 
     def _set_retvar(self, value: Any, decl_type: Optional[DeclType] = None) -> None:
-        scope = self.scopes[-1]
+        scope = self.runtime.scope
+        state = self.runtime.state
         if decl_type is None:
-            scope.values["retvar"] = copy.deepcopy(value)
-            scope.types["retvar"] = self._infer_decl_type_from_value(value)
+            state["retvar"] = copy.deepcopy(value)
+            scope["retvar"] = self._infer_decl_type_from_value(value)
             return
 
         coerced_value = _coerce_value(value, decl_type)
-        scope.values["retvar"] = copy.deepcopy(coerced_value)
+        state["retvar"] = copy.deepcopy(coerced_value)
         stored_type = decl_type
         if (
             decl_type.kind == "LIST"
@@ -457,7 +452,7 @@ class SelVerIRInterpreter:
             and isinstance(coerced_value, list)
         ):
             stored_type = DeclType("LIST", decl_type.elem_kind or "INT", len(coerced_value))
-        scope.types["retvar"] = stored_type
+        scope["retvar"] = stored_type
 
     def _push_list_packet(self, values: List[Any]) -> None:
         for item in values:
@@ -482,11 +477,7 @@ class SelVerIRInterpreter:
         self.pc = self.label_to_index[label]
 
     def _snapshot_runtime_configuration(self) -> RuntimeConfiguration:
-        self._refresh_public_views()
-        return RuntimeConfiguration(
-            scope=copy.deepcopy(self.scope),
-            state=copy.deepcopy(self.state)
-        )
+        return copy.deepcopy(self.runtime)
 
     # ---------- execution ----------
     def run(
@@ -501,14 +492,14 @@ class SelVerIRInterpreter:
 
             instr = self.code[self.pc]
             self._step(instr)
-            self._refresh_public_views()
             self.steps += 1
 
         self._finish_verifier()
 
+        state, scope = self._refresh_public_views()
         return ExecutionResult(
-            state=copy.deepcopy(self.state),
-            scope=copy.deepcopy(self.scope),
+            state=state,
+            scope=scope,
             stack=copy.deepcopy(self.stack),
             pc=self.pc,
             steps=self.steps,
@@ -669,14 +660,20 @@ class SelVerIRInterpreter:
             return
 
         if op == "CSCOPE":
-            self.scopes.append(self._fresh_scope())
+            self.runtime = self._fresh_runtime(
+                state_parent=self.runtime.state,
+                scope_parent=self.runtime.scope,
+            )
             self.pc += 1
             return
 
         if op == "PSCOPE":
-            if len(self.scopes) == 1:
+            if self.runtime.state.parent is None or self.runtime.scope.parent is None:
                 raise IRRuntimeError("Cannot leave the root scope.")
-            self.scopes.pop()
+            self.runtime = RuntimeConfiguration(
+                state=self.runtime.state.parent,
+                scope=self.runtime.scope.parent,
+            )
             self.pc += 1
             return
 
@@ -693,11 +690,11 @@ class SelVerIRInterpreter:
                 raise IRRuntimeError(f"FUNCENV return type for '{name}' does not match the function table.")
             self.call_stack[-1] = CallFrame(
                 return_pc=frame.return_pc,
-                scopes=frame.scopes,
+                runtime=frame.runtime,
                 function_name=frame.function_name,
                 return_type=return_type if return_type is not None else frame.return_type,
             )
-            self.scopes = [self._fresh_scope()]
+            self.runtime = self._fresh_runtime()
             self.pc += 1
             return
 
@@ -890,8 +887,7 @@ class SelVerIRInterpreter:
 
         if decl_type.kind == "LIST":
             len_name = f"_{name}_len_1"
-            len_scope = self._find_scope_with_value(len_name)
-            if len_scope is not None:
+            if len_name in self.runtime.state:
                 self._push(int(self._get_value(len_name)))
                 return
             self._push(len(self._get_value(name)))
@@ -904,7 +900,7 @@ class SelVerIRInterpreter:
             raise IRRuntimeError("CALL expects one function name or label.")
         target = args[0]
         if not isinstance(target, str) or _INT_RE.fullmatch(target.strip()):
-            self.call_stack.append(CallFrame(return_pc=self.pc + 1, scopes=tuple(self.scopes)))
+            self.call_stack.append(CallFrame(return_pc=self.pc + 1, runtime=self.runtime))
             self._jump_to_label(int(target))
             return
 
@@ -915,7 +911,7 @@ class SelVerIRInterpreter:
         self.call_stack.append(
             CallFrame(
                 return_pc=self.pc + 1,
-                scopes=tuple(self.scopes),
+                runtime=self.runtime,
                 function_name=name,
                 return_type=entry.return_type,
             )
@@ -940,7 +936,7 @@ class SelVerIRInterpreter:
             return_value = self._pop()
 
         frame = self.call_stack.pop()
-        self.scopes = list(frame.scopes)
+        self.runtime = frame.runtime
         self._set_retvar(return_value, return_type)
         self.pc = frame.return_pc
 

--- a/src/selveri/interpreter.py
+++ b/src/selveri/interpreter.py
@@ -13,6 +13,7 @@ from .errors import IRRuntimeError, IRParseError
 from .compiler import IRInstr
 from .runtime import DeclType, Scope, State, _UNSET
 from .SelVerifier.verifier import VerificationEngine
+from .SelVerifier.mapper import Z3Mapper
 
 
 @dataclass
@@ -361,10 +362,12 @@ class SelVerIRInterpreter:
 
     # ---------- lookup ----------
     def _fresh_scope(self, parent: Optional[Scope] = None) -> Scope:
-        return Scope(types={"retvar": None}, parent=parent)
+        depth = parent.depth + 1 if parent is not None else 0
+        return Scope(types={"retvar": None}, depth=depth, parent=parent)
 
     def _fresh_state(self, parent: Optional[State] = None) -> State:
-        return State(values={"retvar": _UNSET}, parent=parent)
+        depth = parent.depth + 1 if parent is not None else 0
+        return State(values={"retvar": _UNSET}, depth=depth, parent=parent)
 
     def _fresh_runtime(
         self,
@@ -734,16 +737,18 @@ class SelVerIRInterpreter:
             self._declare(name, decl_type, 0)
 
             # record the declaration step of the variable
-            if self.verifier is not None and name not in self.verifier.declaration_steps:
-                self.verifier.declaration_steps[name] = self.verifier.last_step
+            name_z3 = Z3Mapper.get_z3_var_name(name, self.runtime.scope.scope_id)
+            if self.verifier is not None and name_z3 not in self.verifier.declaration_steps:
+                self.verifier.declaration_steps[name_z3] = self.verifier.last_step
             return
 
         if decl_type.kind == "FLOAT":
             self._declare(name, decl_type, 0.0)
 
             # record the declaration step of the variable
-            if self.verifier is not None and name not in self.verifier.declaration_steps:
-                self.verifier.declaration_steps[name] = self.verifier.last_step
+            name_z3 = Z3Mapper.get_z3_var_name(name, self.runtime.scope.scope_id)
+            if self.verifier is not None and name_z3 not in self.verifier.declaration_steps:
+                self.verifier.declaration_steps[name_z3] = self.verifier.last_step
             return
 
         if decl_type.kind == "LIST":
@@ -753,8 +758,9 @@ class SelVerIRInterpreter:
             self._declare(name, decl_type, [zero for _ in range(decl_type.size)])
 
             # record the declaration step of the variable
-            if self.verifier is not None and name not in self.verifier.declaration_steps:
-                self.verifier.declaration_steps[name] = self.verifier.last_step
+            name_z3 = Z3Mapper.get_z3_var_name(name, self.runtime.scope.scope_id)
+            if self.verifier is not None and name_z3 not in self.verifier.declaration_steps:
+                self.verifier.declaration_steps[name_z3] = self.verifier.last_step
             return
 
         raise IRRuntimeError(f"Unsupported DECL type: {decl_type}")
@@ -779,8 +785,9 @@ class SelVerIRInterpreter:
         self._declare(name, runtime_type, [zero for _ in range(size)])
 
         # record the declaration step of the variable
-        if self.verifier is not None and name not in self.verifier.declaration_steps:
-            self.verifier.declaration_steps[name] = self.verifier.last_step
+        name_z3 = Z3Mapper.get_z3_var_name(name, self.runtime.scope.scope_id)
+        if self.verifier is not None and name_z3 not in self.verifier.declaration_steps:
+            self.verifier.declaration_steps[name_z3] = self.verifier.last_step
 
     def _exec_push(self, args: Tuple[Any, ...]) -> None:
         if len(args) != 1:
@@ -816,9 +823,11 @@ class SelVerIRInterpreter:
             self._set_value(name, _coerce_value(value, decl_type))
 
             # record the initialization step of the variable
-            if self.verifier is not None and name not in self.verifier.initialization_steps:
-                self.verifier.initialization_steps[name] = self.verifier.last_step
-                del self.verifier.declaration_steps[name]
+            owner = self.runtime.scope.find_owner(name)
+            name_z3 = Z3Mapper.get_z3_var_name(name, owner.scope_id if owner else self.runtime.scope.scope_id)
+            if self.verifier is not None and name_z3 not in self.verifier.initialization_steps:
+                self.verifier.initialization_steps[name_z3] = self.verifier.last_step
+                self.verifier.declaration_steps.pop(name_z3, None)
 
             return
 
@@ -830,9 +839,11 @@ class SelVerIRInterpreter:
             self._set_value(name, list_value)
 
             # record the initialization step of the variable
-            if self.verifier is not None and name not in self.verifier.initialization_steps:
-                self.verifier.initialization_steps[name] = self.verifier.last_step
-                del self.verifier.declaration_steps[name]
+            owner = self.runtime.scope.find_owner(name)
+            name_z3 = Z3Mapper.get_z3_var_name(name, owner.scope_id if owner else self.runtime.scope.scope_id)
+            if self.verifier is not None and name_z3 not in self.verifier.initialization_steps:
+                self.verifier.initialization_steps[name_z3] = self.verifier.last_step
+                self.verifier.declaration_steps.pop(name_z3, None)
 
             return
 
@@ -872,9 +883,11 @@ class SelVerIRInterpreter:
         arr[idx] = _coerce_value(value, elem_type)
 
         # record the initialization step of the variable
-        if self.verifier is not None and name not in self.verifier.initialization_steps:
-            self.verifier.initialization_steps[name] = self.verifier.last_step
-            del self.verifier.declaration_steps[name]
+        owner = self.runtime.scope.find_owner(name)
+        name_z3 = Z3Mapper.get_z3_var_name(name, owner.scope_id if owner else self.runtime.scope.scope_id)
+        if self.verifier is not None and name_z3 not in self.verifier.initialization_steps:
+            self.verifier.initialization_steps[name_z3] = self.verifier.last_step
+            self.verifier.declaration_steps.pop(name_z3, None)
 
     def _exec_len(self, args: Tuple[Any, ...]) -> None:
         if len(args) != 1:

--- a/src/selveri/interpreter.py
+++ b/src/selveri/interpreter.py
@@ -737,18 +737,16 @@ class SelVerIRInterpreter:
             self._declare(name, decl_type, 0)
 
             # record the declaration step of the variable
-            name_z3 = Z3Mapper.get_z3_var_name(name, self.runtime.scope.scope_id)
-            if self.verifier is not None and name_z3 not in self.verifier.declaration_steps:
-                self.verifier.declaration_steps[name_z3] = self.verifier.last_step
+            if self.verifier is not None:
+                self.verifier.register_declaration(name, self.runtime.scope.scope_id)
             return
 
         if decl_type.kind == "FLOAT":
             self._declare(name, decl_type, 0.0)
 
             # record the declaration step of the variable
-            name_z3 = Z3Mapper.get_z3_var_name(name, self.runtime.scope.scope_id)
-            if self.verifier is not None and name_z3 not in self.verifier.declaration_steps:
-                self.verifier.declaration_steps[name_z3] = self.verifier.last_step
+            if self.verifier is not None:
+                self.verifier.register_declaration(name, self.runtime.scope.scope_id)
             return
 
         if decl_type.kind == "LIST":
@@ -758,9 +756,8 @@ class SelVerIRInterpreter:
             self._declare(name, decl_type, [zero for _ in range(decl_type.size)])
 
             # record the declaration step of the variable
-            name_z3 = Z3Mapper.get_z3_var_name(name, self.runtime.scope.scope_id)
-            if self.verifier is not None and name_z3 not in self.verifier.declaration_steps:
-                self.verifier.declaration_steps[name_z3] = self.verifier.last_step
+            if self.verifier is not None:
+                self.verifier.register_declaration(name, self.runtime.scope.scope_id)
             return
 
         raise IRRuntimeError(f"Unsupported DECL type: {decl_type}")
@@ -785,9 +782,8 @@ class SelVerIRInterpreter:
         self._declare(name, runtime_type, [zero for _ in range(size)])
 
         # record the declaration step of the variable
-        name_z3 = Z3Mapper.get_z3_var_name(name, self.runtime.scope.scope_id)
-        if self.verifier is not None and name_z3 not in self.verifier.declaration_steps:
-            self.verifier.declaration_steps[name_z3] = self.verifier.last_step
+        if self.verifier is not None:
+            self.verifier.register_declaration(name, self.runtime.scope.scope_id)
 
     def _exec_push(self, args: Tuple[Any, ...]) -> None:
         if len(args) != 1:
@@ -823,11 +819,8 @@ class SelVerIRInterpreter:
             self._set_value(name, _coerce_value(value, decl_type))
 
             # record the initialization step of the variable
-            owner = self.runtime.scope.find_owner(name)
-            name_z3 = Z3Mapper.get_z3_var_name(name, owner.scope_id if owner else self.runtime.scope.scope_id)
-            if self.verifier is not None and name_z3 not in self.verifier.initialization_steps:
-                self.verifier.initialization_steps[name_z3] = self.verifier.last_step
-                self.verifier.declaration_steps.pop(name_z3, None)
+            if self.verifier is not None:
+                self.verifier.register_initial_assignment(name, self.runtime.scope)
 
             return
 
@@ -839,11 +832,8 @@ class SelVerIRInterpreter:
             self._set_value(name, list_value)
 
             # record the initialization step of the variable
-            owner = self.runtime.scope.find_owner(name)
-            name_z3 = Z3Mapper.get_z3_var_name(name, owner.scope_id if owner else self.runtime.scope.scope_id)
-            if self.verifier is not None and name_z3 not in self.verifier.initialization_steps:
-                self.verifier.initialization_steps[name_z3] = self.verifier.last_step
-                self.verifier.declaration_steps.pop(name_z3, None)
+            if self.verifier is not None:
+                self.verifier.register_initial_assignment(name, self.runtime.scope)
 
             return
 
@@ -883,11 +873,8 @@ class SelVerIRInterpreter:
         arr[idx] = _coerce_value(value, elem_type)
 
         # record the initialization step of the variable
-        owner = self.runtime.scope.find_owner(name)
-        name_z3 = Z3Mapper.get_z3_var_name(name, owner.scope_id if owner else self.runtime.scope.scope_id)
-        if self.verifier is not None and name_z3 not in self.verifier.initialization_steps:
-            self.verifier.initialization_steps[name_z3] = self.verifier.last_step
-            self.verifier.declaration_steps.pop(name_z3, None)
+        if self.verifier is not None:
+            self.verifier.register_initial_assignment(name, self.runtime.scope)
 
     def _exec_len(self, args: Tuple[Any, ...]) -> None:
         if len(args) != 1:
@@ -957,7 +944,6 @@ class SelVerIRInterpreter:
         if self.verifier is None:
             return
         self.verifier.prepare_program(self.code)
-        self.verifier.on_program_start()
 
     def _finish_verifier(self) -> None:
         if self.verifier is None:

--- a/src/selveri/parser.py
+++ b/src/selveri/parser.py
@@ -93,7 +93,6 @@ class FloatLit(Imm, AExp):
     def __str__(self) -> str:
         return str(self.value)
 
-# TODO: we might remove this
 @dataclass(frozen=True)
 class ListLit(Imm, AExp):
     items: List[Imm]

--- a/src/selveri/runtime.py
+++ b/src/selveri/runtime.py
@@ -17,6 +17,90 @@ _UNSET = object()
 
 
 @dataclass
-class RuntimeScope:
+class State:
     values: Dict[str, Any]
+    parent: Optional["State"] = None
+
+    def __contains__(self, name: str) -> bool:
+        return self.find_owner(name) is not None
+
+    def __getitem__(self, name: str) -> Any:
+        owner = self.find_owner(name)
+        if owner is None:
+            raise KeyError(name)
+        return owner.values[name]
+
+    def __setitem__(self, name: str, value: Any) -> None:
+        self.values[name] = value
+
+    def get(self, name: str, default: Any = None) -> Any:
+        owner = self.find_owner(name)
+        if owner is None:
+            return default
+        return owner.values[name]
+
+    def items(self):
+        return self.visible_values().items()
+
+    def find_owner(self, name: str) -> Optional["State"]:
+        cur: Optional[State] = self
+        while cur is not None:
+            if name in cur.values:
+                return cur
+            cur = cur.parent
+        return None
+
+    def visible_values(self) -> Dict[str, Any]:
+        visible: Dict[str, Any] = {}
+        cur: Optional[State] = self
+        while cur is not None:
+            for name, value in cur.values.items():
+                if value is not _UNSET and name not in visible:
+                    visible[name] = value
+            cur = cur.parent
+        return visible
+
+
+@dataclass
+class Scope:
     types: Dict[str, Optional[DeclType]]
+    parent: Optional["Scope"] = None
+
+    def __contains__(self, name: str) -> bool:
+        return self.find_owner(name) is not None
+
+    def __getitem__(self, name: str) -> Optional[DeclType]:
+        owner = self.find_owner(name)
+        if owner is None:
+            raise KeyError(name)
+        return owner.types[name]
+
+    def __setitem__(self, name: str, decl_type: Optional[DeclType]) -> None:
+        self.types[name] = decl_type
+
+    def get(self, name: str, default: Optional[DeclType] = None) -> Optional[DeclType]:
+        owner = self.find_owner(name)
+        if owner is None:
+            return default
+        return owner.types[name]
+
+    def items(self):
+        return self.visible_types().items()
+
+    def find_owner(self, name: str) -> Optional["Scope"]:
+        cur: Optional[Scope] = self
+        while cur is not None:
+            if name in cur.types:
+                return cur
+            cur = cur.parent
+        return None
+
+    def visible_types(self) -> Dict[str, DeclType]:
+        visible: Dict[str, DeclType] = {}
+        cur: Optional[Scope] = self
+        while cur is not None:
+            for name, decl_type in cur.types.items():
+                if decl_type is not None and name not in visible:
+                    visible[name] = decl_type
+            cur = cur.parent
+        return visible

--- a/src/selveri/runtime.py
+++ b/src/selveri/runtime.py
@@ -19,6 +19,7 @@ _UNSET = object()
 @dataclass
 class State:
     values: Dict[str, Any]
+    depth: int
     parent: Optional["State"] = None
 
     def __contains__(self, name: str) -> bool:
@@ -60,11 +61,21 @@ class State:
             cur = cur.parent
         return visible
 
+import itertools
+_scope_id_counter = itertools.count()
 
 @dataclass
 class Scope:
     types: Dict[str, Optional[DeclType]]
+    depth: int
     parent: Optional["Scope"] = None
+    # scope_id provides horizontal isolation: distinguishing between different 
+    # blocks at the same depth (e.g. consecutive if-blocks or while-loop iterations)
+    scope_id: int = -1
+
+    def __post_init__(self):
+        if self.scope_id == -1:
+            object.__setattr__(self, 'scope_id', next(_scope_id_counter))
 
     def __contains__(self, name: str) -> bool:
         return self.find_owner(name) is not None

--- a/src/selveri/spec_parser.py
+++ b/src/selveri/spec_parser.py
@@ -99,7 +99,7 @@ class SpecAstBuilder(Transformer):
     def truthy(self, aexp): return BTruthy(aexp)
 
     # specs
-    def sbexp(self, bexp: BExp): return SpecFromBExp(self._next_uid(), SpecType.FOL, bexp) # TODO: can it have a type other than FOL?
+    def sbexp(self, bexp: BExp): return SpecFromBExp(self._next_uid(), SpecType.FOL, bexp)
     def snot(self, rhs: Spec): return SpecUnOp(self._next_uid(), rhs.type, "!", rhs)
     def spreviously(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.pLTL, "Previously", rhs)
     def sonce(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.pLTL, "Once", rhs)


### PR DESCRIPTION
Implemented State and Scope classes for clarity.

Overriden getitem and setitem operators to make state[name] and scope[name] work directly without any need to use the field names. Also implemented some helper functions just in case.

Closes #54.