### PR TITLE
Fix: general verifier bug fixes.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Future LTL (fLTL) lowers to MONA via ltlf2dfa; pass/fail verifier tests hit this path.
+      - name: Install MONA (Future LTL)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mona
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Run test suite
+        run: bash run_tests.sh

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ Or install the project in editable mode to enable the `selveri` command:
 pip install -e .
 ```
 
+### Future LTL (fLTL) and MONA
+
+Specs using temporal operators such as **Eventually**, **Always**, and **Until** are verified by compiling an automaton through [MONA](https://www.brics.dk/mona/). The `mona` executable must be on your `PATH`; otherwise SelVeri raises a verification error for those specs.
+
+**Linux (Debian/Ubuntu)** — MONA is packaged as `mona` in the universe repository:
+
+```
+sudo apt update
+sudo apt install mona
+```
+
+**macOS / Windows** — Install from the [official MONA page](https://www.brics.dk/mona/), or use a Linux environment (**WSL** on Windows, then follow the Debian/Ubuntu steps).
+
+To confirm:
+
+```
+mona -h
+```
+
 ## Run Full Pipeline
 
 Run parser -> compiler -> interpreter from the project root:

--- a/examples/verifier_tests/fail_tests/fol_basic_fail.svi
+++ b/examples/verifier_tests/fail_tests/fol_basic_fail.svi
@@ -13,9 +13,9 @@ z := 10;
 
 // ---- Uncomment one at a time to test each failure ----
 
-//{ x = 5 };            // False
+// { x = 5 };            // False
 // { x < y };         // False
-// { x < z };         // False (not strict)
+ { x < z };         // False (not strict)
 // { x <= y };        // False
 // { y > x };         // False
 // { x > z };         // False

--- a/examples/verifier_tests/pass_test/fol_quantifiers.svi
+++ b/examples/verifier_tests/pass_test/fol_quantifiers.svi
@@ -70,3 +70,25 @@ mixed : List[Int, 1, 6];
 mixed := [0, 5, 0, 10, 0, 15];
 
 { Forall i in [0...5] . (mixed[&i] > 0) => (mixed[&i] >= 5) };  // True
+
+// ==============================
+// Forall with variable domain
+// ==============================
+
+
+{ Forall x in Var[Int]. &x > 0 }; // True
+{ Exists j in Var[Int]. &j = 4 };  // True
+
+neg : Int;
+neg := -7;
+{ Exists x in Var[Int]. &x <= 0 }; // True, with neg
+
+
+p : Float;
+p := 3.14159;
+e : Float;
+e := 2.71828;
+
+{ Forall x in Var[Float]. &x > 0 }; // True, with p, e
+{ Forall x in Var[Float]. &x < 4 }; // True, with p, e
+{ Exists x in Var[Float]. &x = 3.14159 }; // True, with p

--- a/examples/verifier_tests/pass_test/fol_quantifiers.svi
+++ b/examples/verifier_tests/pass_test/fol_quantifiers.svi
@@ -39,8 +39,8 @@ b := 4;
 c : Int;
 c := 6;
 
-//{ Forall v in [a, b, c] . &v > 0 };       // True
-//{ Exists v in [a, b, c] . &v = 4 };       // True
+{ Forall v in [a, b, c] . &v > 0 };       // True
+{ Exists v in [a, b, c] . &v = 4 };       // True
 
 // ==============================
 // Nested Quantifiers

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SelVerifier Test Runner
+# Runs all pass and fail tests and reports results.
+
+set -uo pipefail
+
+PASS_DIR="examples/verifier_tests/pass_test"
+FAIL_DIR="examples/verifier_tests/fail_tests"
+EXAMPLES_DIR="examples"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+passed=0
+failed=0
+skipped=0
+total=0
+failures=()
+
+echo -e "${BOLD}══════════════════════════════════════════${RESET}"
+echo -e "${BOLD}       SelVerifier Test Suite${RESET}"
+echo -e "${BOLD}══════════════════════════════════════════${RESET}"
+echo
+
+# ── Examples ────────────────────────────────────
+echo -e "${BOLD}▶ Examples${RESET} (expected: compile and run without error)"
+echo -e "  Directory: ${EXAMPLES_DIR}"
+echo
+
+for f in "$EXAMPLES_DIR"/*.svi; do
+    [ -f "$f" ] || continue
+    name=$(basename "$f")
+    total=$((total + 1))
+
+    output=$(selveri "$f" 2>&1)
+    exit_code=$?
+
+    if [ $exit_code -eq 0 ]; then
+        steps=$(echo "$output" | grep -oP 'Steps:\s*\K\d+' || echo "?")
+        echo -e "  ${GREEN}✓${RESET} ${name}  (${steps} steps)"
+        passed=$((passed + 1))
+    else
+        echo -e "  ${RED}✗${RESET} ${name}"
+        echo "$output" | tail -1 | sed 's/^/      /'
+        failed=$((failed + 1))
+        failures+=("EXAMPLE  $name")
+    fi
+done
+
+echo
+
+# ── Pass Tests ──────────────────────────────────
+echo -e "${BOLD}▶ Pass Tests${RESET} (expected: run without error)"
+echo -e "  Directory: ${PASS_DIR}"
+echo
+
+for f in "$PASS_DIR"/*.svi; do
+    [ -f "$f" ] || continue
+    name=$(basename "$f")
+    total=$((total + 1))
+
+    output=$(selveri "$f" 2>&1)
+    exit_code=$?
+
+    if [ $exit_code -eq 0 ]; then
+        steps=$(echo "$output" | grep -oP 'Steps:\s*\K\d+' || echo "?")
+        echo -e "  ${GREEN}✓${RESET} ${name}  (${steps} steps)"
+        passed=$((passed + 1))
+    else
+        echo -e "  ${RED}✗${RESET} ${name}"
+        echo "$output" | tail -1 | sed 's/^/      /'
+        failed=$((failed + 1))
+        failures+=("PASS  $name")
+    fi
+done
+
+echo
+
+# ── Fail Tests ──────────────────────────────────
+echo -e "${BOLD}▶ Fail Tests${RESET} (expected: VerificationError)"
+echo -e "  Directory: ${FAIL_DIR}"
+echo
+
+for f in "$FAIL_DIR"/*.svi; do
+    [ -f "$f" ] || continue
+    name=$(basename "$f")
+    total=$((total + 1))
+
+    output=$(selveri "$f" 2>&1)
+    exit_code=$?
+
+    if echo "$output" | grep -q "VerificationError"; then
+        spec=$(echo "$output" | grep -oP 'Specification #\K\d+' || echo "?")
+        echo -e "  ${GREEN}✓${RESET} ${name}  (failed at spec #${spec})"
+        passed=$((passed + 1))
+    elif [ $exit_code -eq 0 ]; then
+        # Check if the file has any active (uncommented) specs
+        active_specs=$(grep -cP '^\s*\{' "$f" || true)
+        if [ "$active_specs" -eq 0 ]; then
+            echo -e "  ${YELLOW}⊘${RESET} ${name}  (no active specs — skipped)"
+            skipped=$((skipped + 1))
+        else
+            echo -e "  ${RED}✗${RESET} ${name}  (unexpected pass)"
+            failed=$((failed + 1))
+            failures+=("FAIL  $name  (should have raised VerificationError)")
+        fi
+    else
+        echo -e "  ${RED}✗${RESET} ${name}  (crashed with non-verification error)"
+        echo "$output" | tail -1 | sed 's/^/      /'
+        failed=$((failed + 1))
+        failures+=("FAIL  $name  (unexpected crash)")
+    fi
+done
+
+echo
+echo -e "${BOLD}══════════════════════════════════════════${RESET}"
+
+# ── Summary ─────────────────────────────────────
+if [ $failed -eq 0 ]; then
+    echo -e "  ${GREEN}${BOLD}All tests passed!${RESET}"
+else
+    echo -e "  ${RED}${BOLD}Some tests failed.${RESET}"
+fi
+
+echo -e "  Total: ${total}  ${GREEN}Passed: ${passed}${RESET}  ${RED}Failed: ${failed}${RESET}  ${YELLOW}Skipped: ${skipped}${RESET}"
+
+if [ ${#failures[@]} -gt 0 ]; then
+    echo
+    echo -e "  ${RED}Failures:${RESET}"
+    for f in "${failures[@]}"; do
+        echo -e "    • $f"
+    done
+fi
+
+echo -e "${BOLD}══════════════════════════════════════════${RESET}"
+
+exit $failed

--- a/src/selveri/SelVerifier/mapper.py
+++ b/src/selveri/SelVerifier/mapper.py
@@ -165,29 +165,29 @@ class Z3Mapper():
 
     def map_FOL_listlit(self, aexp: ListLit) -> z3types.ExprRef:
         stack: list = [aexp]
-        flat_imms: list = []
+        flat_elems: list = []
         while stack:
             node = stack.pop()
             if isinstance(node, ListLit):
                 for item in reversed(node.items):
                     stack.append(item)
-            elif isinstance(node, IntLit):
-                flat_imms.append(node)
-            elif isinstance(node, FloatLit):
-                flat_imms.append(node)
             else:
-                raise VerifierRuntimeError(f"Unsupported list literal element: {node}")
-        if not flat_imms:
+                flat_elems.append(node)
+        if not flat_elems:
             raise VerifierRuntimeError("Empty list literal is not supported in specifications")
-        use_real = any(isinstance(x, FloatLit) for x in flat_imms)
+        mapped = [self.map_FOL_aexp(x) for x in flat_elems]
+        use_real = any(isinstance(x, FloatLit) for x in flat_elems) or any(
+            me.is_real() for me in mapped
+        )
         if use_real:
             arr = K(IntSort(), RealVal(0))
-            for i, imm in enumerate(flat_imms):
-                arr = Store(arr, IntVal(i), RealVal(imm.value))
+            for i, me in enumerate(mapped):
+                el = ToReal(me) if me.is_int() else me
+                arr = Store(arr, IntVal(i), el)
         else:
             arr = K(IntSort(), IntVal(0))
-            for i, imm in enumerate(flat_imms):
-                arr = Store(arr, IntVal(i), IntVal(imm.value))
+            for i, me in enumerate(mapped):
+                arr = Store(arr, IntVal(i), me)
         return arr
 
     def map_FOL_aindex(self, aexp: AIndex) -> z3types.ExprRef:

--- a/src/selveri/SelVerifier/mapper.py
+++ b/src/selveri/SelVerifier/mapper.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any, Dict
 from z3 import *
 
-from ..runtime import Scope, State
+from ..runtime import Scope, State, _UNSET
 from ..defs import RuntimeConfiguration
 from ..specs import Spec, SpecFromBExp, SpecUnOp, SpecBinOp, SpecQuant, Domain, DomainIdent, DomainInterval, DomainRange, DomainType, DomainValues, DomainVar
 from ..spec_parser import ABoundVar
@@ -44,7 +44,7 @@ class Z3Mapper():
     ######### Configuration Mapping #########    
 
     def map_scope(self, scope: Scope) -> Dict[str, z3types.ExprRef]:
-        for var, vartype in scope.items():
+        for var, vartype in scope.types.items():  # local scope only; parents handled by recursion
             if vartype is None:
                 continue
             
@@ -68,11 +68,13 @@ class Z3Mapper():
             self.map_scope(scope.parent)
 
     def map_state(self, state : State, scope: Scope, solver : Solver) -> None:
-        for var, value in state.items():
-            if var not in scope:
+        for var, value in state.values.items():  # local state only; parents handled by recursion
+            if value is _UNSET:
+                continue
+            if var not in scope.types:
                 raise VerifierRuntimeError(f"Variable {var} not found in scope")
             try:
-                vartype = scope[var]
+                vartype = scope.types.get(var)
                 if vartype is None:
                     continue
                 var_z3_name = Z3Mapper.get_z3_var_name(var, scope.scope_id)
@@ -299,7 +301,7 @@ class Z3Mapper():
                 result = ForAll(bound_var_z3, self.map_FOL(spec.body))
             else: # QuantifierType.Exists
                 result = Exists(bound_var_z3, self.map_FOL(spec.body))
-            del self.bound_var_map[bound_var]
+            self.bound_var_map.pop(bound_var, None)
             return result
         elif isinstance(domain, DomainRange):
             bound_var_z3 = Int("&" + bound_var)
@@ -311,7 +313,7 @@ class Z3Mapper():
                 result = ForAll(bound_var_z3, Implies(domain_z3, self.map_FOL(spec.body)))
             else: # QuantifierType.Exists
                 result = Exists(bound_var_z3, And(domain_z3, self.map_FOL(spec.body)))
-            del self.bound_var_map[bound_var]
+            self.bound_var_map.pop(bound_var, None)
             return result
         elif isinstance(domain, DomainInterval):
             bound_var_z3 = Real("&" + bound_var)
@@ -331,7 +333,7 @@ class Z3Mapper():
                 result = ForAll(bound_var_z3, Implies(domain_z3, self.map_FOL(spec.body)))
             else: # QuantifierType.Exists
                 result = Exists(bound_var_z3, And(domain_z3, self.map_FOL(spec.body)))
-            del self.bound_var_map[bound_var]
+            self.bound_var_map.pop(bound_var, None)
             return result
         else: # uses finite_connector over finite domain
             result_list = list()
@@ -341,8 +343,14 @@ class Z3Mapper():
                     raise VerifierRuntimeError(f"Variable {domain.name} (Z3 name: {domain_z3_name}) not mapped")
                 if not is_array(self.free_var_map[domain_z3_name]):
                     raise VerifierRuntimeError(f"Variable {domain.name} is not a list")
-                # TODO: consider multi-dim lists
-                for i in range(self.state[f"_{domain.name}_len_1"]):
+                # Use scope-aware type resolution for list length
+                owner_scope = self._get_lexical_scope().find_owner(domain.name)
+                if owner_scope is None:
+                    raise VerifierRuntimeError(f"List {domain.name} not found in lexical scope")
+                list_type = owner_scope.types.get(domain.name)
+                if list_type is None or list_type.kind != "LIST" or list_type.size is None:
+                    raise VerifierRuntimeError(f"Cannot determine size of list {domain.name}")
+                for i in range(list_type.size):
                     self.bound_var_map[bound_var] = self.map_FOL_aexp(AIndex(AVar(domain.name), IntLit(i)))
                     result_list.append(self.map_FOL(spec.body))     
             elif isinstance(domain, DomainValues):
@@ -362,7 +370,7 @@ class Z3Mapper():
             else:
                 raise VerifierRuntimeError(f"Unsupported domain type: {domain}")
                 
-            del self.bound_var_map[bound_var]
+            self.bound_var_map.pop(bound_var, None)
             if quantifier == QuantifierType.Forall:
                 return And(result_list)
             else: # QuantifierType.Exists

--- a/src/selveri/SelVerifier/verifier.py
+++ b/src/selveri/SelVerifier/verifier.py
@@ -270,7 +270,7 @@ class VerificationEngine:
             self._aexp_get_free_variables(bexp.aexp, variables)
 
     def _aexp_get_free_variables(self, aexp: Any, variables: set[str]) -> None:
-        from ..parser import AVar, ALen, AIndex, AUnOp, ABinOp, IntLit, FloatLit, FuncCall
+        from ..parser import AVar, ALen, AIndex, AUnOp, ABinOp, IntLit, FloatLit, FuncCall, ListLit
         from ..spec_parser import ABoundVar
         if isinstance(aexp, ABoundVar):
             pass  # bound variables are not free; handled by _spec_get_free_variables via SpecQuant.discard
@@ -289,7 +289,10 @@ class VerificationEngine:
         elif isinstance(aexp, FuncCall):
             for arg in aexp.args:
                 self._aexp_get_free_variables(arg, variables)
-        # IntLit, FloatLit, ListLit — no variables
+        elif isinstance(aexp, ListLit):
+            for item in aexp.items:
+                self._aexp_get_free_variables(item, variables)
+        # IntLit, FloatLit — no variables
 
     def _domain_get_free_variables(self, domain: Any, variables: set[str]) -> None:
         from ..specs import DomainIdent, DomainValues, DomainRange, DomainInterval

--- a/src/selveri/SelVerifier/verifier.py
+++ b/src/selveri/SelVerifier/verifier.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List, Optional
-from z3 import Not, Solver, simplify, unsat
+from z3 import Not, Solver, simplify, sat, unsat, unknown
 from sympy import Basic
 
 from ..compiler import IRInstr
@@ -14,6 +14,9 @@ from .future_mapper import FutureLTLMapper
 from .mapper import Z3Mapper
 
 class VerificationEngine:
+
+    SOLVER_TIMEOUT = 60000 # 1 minute timeout for each solver check.
+
     def __init__(self):
         self.last_step = 0
         self.declaration_steps: Dict[str, int] = dict() # stores the declaration steps of variable
@@ -143,13 +146,15 @@ class VerificationEngine:
         solver = Solver()
         mapper = Z3Mapper(snapshot, solver, lexical_depth)
         negated_assumption = simplify(Not(mapper.map_FOL(spec)))
-        result = solver.check(negated_assumption)
+        solver.set("timeout", VerificationEngine.SOLVER_TIMEOUT); result = solver.check(negated_assumption)
         if result == unsat:
             return True
-        else: # sat
+        elif result == sat:
             # TODO: consider giving a counter-example, using the model
             # model : ModelRef = solver.model()
             return False
+        else: # unknown
+            raise VerificationError(f"Z3-solver returned unknown for FOL verification. Reason: {solver.reason_unknown()}")
 
 
     ################# pLTL Verification #################
@@ -179,6 +184,8 @@ class VerificationEngine:
                     result = self.verify_past_LTL(spec.rhs, step, start_step, lexical_depth)
                 else:
                     result = self.verify_past_LTL(spec.rhs, step, start_step, lexical_depth) and self.verify_past_LTL(spec, step - 1, start_step, lexical_depth)
+            else:
+                raise VerificationError(f"Unsupported unary operator for pLTL: {spec.op}")
 
         elif isinstance(spec, SpecBinOp):
             if spec.op == "&&":
@@ -194,6 +201,8 @@ class VerificationEngine:
                 else:
                     left = self.verify_past_LTL(spec.left, step, start_step, lexical_depth)
                     result = right or (left and self.verify_past_LTL(spec, step - 1, start_step, lexical_depth))
+            else:
+                raise VerificationError(f"Unsupported binary operator for pLTL: {spec.op}")
         
         else:
             raise VerificationError(f"Unexpected specification type for pLTL: {spec.type}")
@@ -262,7 +271,10 @@ class VerificationEngine:
 
     def _aexp_get_free_variables(self, aexp: Any, variables: set[str]) -> None:
         from ..parser import AVar, ALen, AIndex, AUnOp, ABinOp, IntLit, FloatLit, FuncCall
-        if isinstance(aexp, AVar):
+        from ..spec_parser import ABoundVar
+        if isinstance(aexp, ABoundVar):
+            pass  # bound variables are not free; handled by _spec_get_free_variables via SpecQuant.discard
+        elif isinstance(aexp, AVar):
             variables.add(aexp.name)
         elif isinstance(aexp, ALen):
             variables.add(aexp.name)

--- a/src/selveri/grammars/spec_grammar.lark
+++ b/src/selveri/grammars/spec_grammar.lark
@@ -81,7 +81,7 @@ aexp_list: aexp ("," aexp)*                -> aexp_list
     | FLOAT_LIT                            -> float_lit
     | list_lit
 
-list_lit: "[" [imm ("," imm)*] "]"
+list_lit: "[" [aexp ("," aexp)*] "]"
 
 aexp: aexp_sum                             -> aexp
 

--- a/src/selveri/spec_parser.py
+++ b/src/selveri/spec_parser.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from lark import Lark, LarkError, Transformer, v_args
 
 from .errors import ParserError, VerifierRuntimeError
+from .runtime import DeclType
 from .parser import (
     ABinOp,
     ALen,
@@ -28,6 +29,15 @@ from .parser import (
     TypeInt,
     TypeList,
 )
+def _basic_type_to_decl_type(bt):
+    """Convert a parser-level BasicType (TypeInt/TypeFloat) to a runtime DeclType."""
+    if isinstance(bt, TypeInt):
+        return DeclType("INT", None, None)
+    elif isinstance(bt, TypeFloat):
+        return DeclType("FLOAT", None, None)
+    else:
+        raise ParserError(f"Unsupported type for quantifier domain: {bt}")
+
 from .specs import (
     DomainIdent,
     DomainInterval,
@@ -124,8 +134,8 @@ class SpecAstBuilder(Transformer):
     def domain_ident(self, name): return DomainIdent(str(name))
     def domain_range(self, lo, hi): return DomainRange(lo, hi)
     def domain_values(self, lit: ListLit): return DomainValues(list(lit.items))
-    def domain_type(self, type_node: BasicType): return DomainType(type_node)
-    def domain_var(self, elem_ty: BasicType): return DomainVar(elem_ty)
+    def domain_type(self, type_node: BasicType): return DomainType(_basic_type_to_decl_type(type_node))
+    def domain_var(self, elem_ty: BasicType): return DomainVar(_basic_type_to_decl_type(elem_ty))
     def interval_closed(self, lo, hi): return DomainInterval(lo, hi, left_closed=True, right_closed=True)
     def interval_open(self, lo, hi): return DomainInterval(lo, hi, left_closed=False, right_closed=False)
     def interval_halfopen(self, lo, hi): return DomainInterval(lo, hi, left_closed=True, right_closed=False)

--- a/src/selveri/specs.py
+++ b/src/selveri/specs.py
@@ -42,7 +42,7 @@ class DomainIdent(Domain):
 
 @dataclass(frozen=True)
 class DomainValues(Domain):
-    """Domain of values drawn from a list of literals."""   
+    """Domain of values drawn from an explicit list of arithmetic expressions."""   
     items: List[AExp]
 
     def __str__(self) -> str:


### PR DESCRIPTION
This PR (also closes #64.) fixes some SelVerifier bugs, detected by Claude Opus 4.6. Here is the report:

# SelVerifier Bug Audit & Fix Report

## Overview

An audit of the SelVerifier subsystem uncovered **7 bugs** across [mapper.py](file:///home/josephus/Desktop/selveri/src/selveri/SelVerifier/mapper.py), [verifier.py](file:///home/josephus/Desktop/selveri/src/selveri/SelVerifier/verifier.py), and [spec_parser.py](file:///home/josephus/Desktop/selveri/src/selveri/spec_parser.py). All stem from a common theme: **mismatched type representations** between the parser layer and the runtime/verifier layer, plus several **unsafe or under-guarded operations**.

All fixes were verified against the full test suite (13 pass tests, 9 fail tests).

---

## Bug 1 — `DomainVar.elem` stores a parser AST type, not a runtime `DeclType`

**Severity:** 🔴 Crash  
**Symptom:** `Exists j in Var[Int]. &j = 4` always fails verification (no variables match), then crashes with `KeyError` on cleanup.

The spec parser's `domain_var` method stored a raw `TypeInt()` parser node into `DomainVar.elem`. But the mapper compared it against scope variable types, which are `DeclType("INT", None, None)`. These are entirely different classes, so `==` was always `False` — meaning `Var[Int]`/`Var[Float]` domains silently matched zero variables.

**Fix:** Added a [_basic_type_to_decl_type](file:///home/josephus/Desktop/selveri/src/selveri/spec_parser.py#L31-L38) converter in `spec_parser.py`. Both `domain_var` and `domain_type` now store proper `DeclType` objects at construction time.

```diff:spec_parser.py
from __future__ import annotations

from dataclasses import dataclass
from itertools import count
from pathlib import Path

from lark import Lark, LarkError, Transformer, v_args

from .errors import ParserError, VerifierRuntimeError
from .parser import (
    ABinOp,
    ALen,
    AExp,
    AIndex,
    AUnOp,
    AVar,
    BBinOp,
    BBool,
    BCompare,
    BExp,
    BNot,
    BTruthy,
    BasicType,
    FloatLit,
    IntLit,
    ListLit,
    TypeFloat,
    TypeInt,
    TypeList,
)
from .specs import (
    DomainIdent,
    DomainInterval,
    DomainRange,
    DomainType,
    DomainValues,
    DomainVar,
    Spec,
    SpecBinOp,
    SpecFromBExp,
    SpecQuant,
    SpecUnOp,
    SpecType
)

@dataclass(frozen=True)
class ABoundVar(AExp):
    name: str

    def __str__(self) -> str:
        return f"&{self.name}"

# Keep formula-node identities distinct even across separate parse_spec calls.
_SPEC_NODE_UIDS = count()


@v_args(inline=True)
class SpecAstBuilder(Transformer):
    def _next_uid(self) -> int:
        return next(_SPEC_NODE_UIDS)

    def start(self, spec: Spec) -> Spec: return spec

    # types
    def type_int(self) -> TypeInt: return TypeInt()

    def type_float(self) -> TypeFloat: return TypeFloat()

    def type_list(self, elem: BasicType, dimension, shape): return TypeList(elem, IntLit(int(dimension)), shape)

    def aexp_list(self, *items): return list(items)
    def aexp(self, expr): return expr
    def int_lit(self, tok): return IntLit(int(tok))
    def float_lit(self, tok): return FloatLit(float(tok))
    def list_lit(self, *args): return ListLit(list(args))
    def a_var(self, name): return AVar(str(name))
    def a_bound_var(self, name): return ABoundVar(str(name))

    def a_len(self, name): return ALen(str(name))
    def a_index(self, base, idx): 
        if not isinstance(base, AExp): 
            base = AVar(str(base)) 
        return AIndex(base, idx)  
    def neg(self, rhs): return AUnOp("-", rhs)
    def add(self, l, r): return ABinOp("+", l, r)
    def sub(self, l, r): return ABinOp("-", l, r)
    def mul(self, l, r): return ABinOp("*", l, r)
    def div(self, l, r): return ABinOp("/", l, r)

    # boolean
    def bexp(self, expr): return expr
    def btrue(self): return BBool(True)
    def bfalse(self): return BBool(False)
    def bnot(self, rhs): return BNot(rhs)
    def band(self, l, r): return BBinOp("and", l, r)
    def bxor(self, l, r): return BBinOp("xor", l, r)
    def bor(self, l, r): return BBinOp("or", l, r)
    def compare(self, l, op, r): return BCompare(str(op), l, r)
    def truthy(self, aexp): return BTruthy(aexp)

    # specs
    def sbexp(self, bexp: BExp): return SpecFromBExp(self._next_uid(), SpecType.FOL, bexp)
    def snot(self, rhs: Spec): return SpecUnOp(self._next_uid(), rhs.type, "!", rhs)
    def spreviously(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.pLTL, "Previously", rhs)
    def sonce(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.pLTL, "Once", rhs)
    def shistorically(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.pLTL, "Historically", rhs)
    def snext(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.fLTL, "Next", rhs)
    def seventually(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.fLTL, "Eventually", rhs)
    def salways(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.fLTL, "Always", rhs)
    def ssince(self, l: Spec, r: Spec): return SpecBinOp(self._next_uid(), self.deduce_past_type(l, r), "Since", l, r)
    def suntil(self, l: Spec, r: Spec): return SpecBinOp(self._next_uid(), self.deduce_future_type(l, r), "Until", l, r)
    def sand(self, l: Spec, r: Spec): return SpecBinOp(self._next_uid(), self.deduce_spec_type(l,r), "&&", l, r)
    def sor(self, l: Spec, r: Spec): return SpecBinOp(self._next_uid(), self.deduce_spec_type(l,r), "||", l, r)
    def simp(self, l: Spec, r: Spec): return SpecBinOp(self._next_uid(), self.deduce_spec_type(l,r), "=>", l, r)
    # state_spec subgrammar (non-temporal quantified bodies; same AST as temporal-level operators)
    def state_snot(self, rhs: Spec): return self.snot(rhs)
    def state_sand(self, l: Spec, r: Spec): return self.sand(l, r)
    def state_sor(self, l: Spec, r: Spec): return self.sor(l, r)
    def state_simp(self, l: Spec, r: Spec): return self.simp(l, r)
    def state_sbexp(self, bexp: BExp): return self.sbexp(bexp)
    def state_forall(self, var, domain, body): return self.sforall(var, domain, body)
    def state_exists(self, var, domain, body): return self.sexists(var, domain, body)
    # domains
    def domain_ident(self, name): return DomainIdent(str(name))
    def domain_range(self, lo, hi): return DomainRange(lo, hi)
    def domain_values(self, lit: ListLit): return DomainValues(list(lit.items))
    def domain_type(self, type_node: BasicType): return DomainType(type_node)
    def domain_var(self, elem_ty: BasicType): return DomainVar(elem_ty)
    def interval_closed(self, lo, hi): return DomainInterval(lo, hi, left_closed=True, right_closed=True)
    def interval_open(self, lo, hi): return DomainInterval(lo, hi, left_closed=False, right_closed=False)
    def interval_halfopen(self, lo, hi): return DomainInterval(lo, hi, left_closed=True, right_closed=False)
    def interval_halfclosed(self, lo, hi): return DomainInterval(lo, hi, left_closed=False, right_closed=True)
    def sforall(self, var, domain, body): 
        if body.type != SpecType.FOL:
            raise VerifierRuntimeError("LTL formulae cannot be quantified!")
        return SpecQuant(self._next_uid(), SpecType.FOL, "Forall", str(var), domain, body)

    def sexists(self, var, domain, body): 
        if body.type != SpecType.FOL:
            raise VerifierRuntimeError("LTL formulae cannot be quantified!")
        return SpecQuant(self._next_uid(), SpecType.FOL, "Exists", str(var), domain, body)


    def deduce_spec_type(self, spec1 : Spec, spec2: Spec) -> SpecType:
        if spec1.type == spec2.type:
            return spec1.type
        if spec1.type == SpecType.FOL:
            return spec2.type
        if spec2.type == SpecType.FOL:
            return spec2.type
        raise VerifierRuntimeError("Mixed LTL formulae are not allowed!")

    def deduce_past_type(self, spec1: Spec, spec2: Spec) -> SpecType:
        if SpecType.fLTL in {spec1.type, spec2.type}:
            raise VerifierRuntimeError("Mixed LTL formulae are not allowed!")
        return SpecType.pLTL

    def deduce_future_type(self, spec1: Spec, spec2: Spec) -> SpecType:
        if SpecType.pLTL in {spec1.type, spec2.type}:
            raise VerifierRuntimeError("Mixed LTL formulae are not allowed!")
        return SpecType.fLTL


SPEC_PARSER = Lark.open(
    str(Path(__file__).resolve().parent / "grammars" / "spec_grammar.lark"),
    parser="lalr",
    lexer="contextual",
    maybe_placeholders=False,
)


def parse_spec(src: str) -> Spec:
    try:
        tree = SPEC_PARSER.parse(src)
    except LarkError as e:
        raise ParserError("Failed to parse SelVeri specification. " + str(e)) from None
    return SpecAstBuilder().transform(tree)
    
===
from __future__ import annotations

from dataclasses import dataclass
from itertools import count
from pathlib import Path

from lark import Lark, LarkError, Transformer, v_args

from .errors import ParserError, VerifierRuntimeError
from .runtime import DeclType
from .parser import (
    ABinOp,
    ALen,
    AExp,
    AIndex,
    AUnOp,
    AVar,
    BBinOp,
    BBool,
    BCompare,
    BExp,
    BNot,
    BTruthy,
    BasicType,
    FloatLit,
    IntLit,
    ListLit,
    TypeFloat,
    TypeInt,
    TypeList,
)
def _basic_type_to_decl_type(bt):
    """Convert a parser-level BasicType (TypeInt/TypeFloat) to a runtime DeclType."""
    if isinstance(bt, TypeInt):
        return DeclType("INT", None, None)
    elif isinstance(bt, TypeFloat):
        return DeclType("FLOAT", None, None)
    else:
        raise ParserError(f"Unsupported type for quantifier domain: {bt}")

from .specs import (
    DomainIdent,
    DomainInterval,
    DomainRange,
    DomainType,
    DomainValues,
    DomainVar,
    Spec,
    SpecBinOp,
    SpecFromBExp,
    SpecQuant,
    SpecUnOp,
    SpecType
)

@dataclass(frozen=True)
class ABoundVar(AExp):
    name: str

    def __str__(self) -> str:
        return f"&{self.name}"

# Keep formula-node identities distinct even across separate parse_spec calls.
_SPEC_NODE_UIDS = count()


@v_args(inline=True)
class SpecAstBuilder(Transformer):
    def _next_uid(self) -> int:
        return next(_SPEC_NODE_UIDS)

    def start(self, spec: Spec) -> Spec: return spec

    # types
    def type_int(self) -> TypeInt: return TypeInt()

    def type_float(self) -> TypeFloat: return TypeFloat()

    def type_list(self, elem: BasicType, dimension, shape): return TypeList(elem, IntLit(int(dimension)), shape)

    def aexp_list(self, *items): return list(items)
    def aexp(self, expr): return expr
    def int_lit(self, tok): return IntLit(int(tok))
    def float_lit(self, tok): return FloatLit(float(tok))
    def list_lit(self, *args): return ListLit(list(args))
    def a_var(self, name): return AVar(str(name))
    def a_bound_var(self, name): return ABoundVar(str(name))

    def a_len(self, name): return ALen(str(name))
    def a_index(self, base, idx): 
        if not isinstance(base, AExp): 
            base = AVar(str(base)) 
        return AIndex(base, idx)  
    def neg(self, rhs): return AUnOp("-", rhs)
    def add(self, l, r): return ABinOp("+", l, r)
    def sub(self, l, r): return ABinOp("-", l, r)
    def mul(self, l, r): return ABinOp("*", l, r)
    def div(self, l, r): return ABinOp("/", l, r)

    # boolean
    def bexp(self, expr): return expr
    def btrue(self): return BBool(True)
    def bfalse(self): return BBool(False)
    def bnot(self, rhs): return BNot(rhs)
    def band(self, l, r): return BBinOp("and", l, r)
    def bxor(self, l, r): return BBinOp("xor", l, r)
    def bor(self, l, r): return BBinOp("or", l, r)
    def compare(self, l, op, r): return BCompare(str(op), l, r)
    def truthy(self, aexp): return BTruthy(aexp)

    # specs
    def sbexp(self, bexp: BExp): return SpecFromBExp(self._next_uid(), SpecType.FOL, bexp)
    def snot(self, rhs: Spec): return SpecUnOp(self._next_uid(), rhs.type, "!", rhs)
    def spreviously(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.pLTL, "Previously", rhs)
    def sonce(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.pLTL, "Once", rhs)
    def shistorically(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.pLTL, "Historically", rhs)
    def snext(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.fLTL, "Next", rhs)
    def seventually(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.fLTL, "Eventually", rhs)
    def salways(self, rhs: Spec): return SpecUnOp(self._next_uid(), SpecType.fLTL, "Always", rhs)
    def ssince(self, l: Spec, r: Spec): return SpecBinOp(self._next_uid(), self.deduce_past_type(l, r), "Since", l, r)
    def suntil(self, l: Spec, r: Spec): return SpecBinOp(self._next_uid(), self.deduce_future_type(l, r), "Until", l, r)
    def sand(self, l: Spec, r: Spec): return SpecBinOp(self._next_uid(), self.deduce_spec_type(l,r), "&&", l, r)
    def sor(self, l: Spec, r: Spec): return SpecBinOp(self._next_uid(), self.deduce_spec_type(l,r), "||", l, r)
    def simp(self, l: Spec, r: Spec): return SpecBinOp(self._next_uid(), self.deduce_spec_type(l,r), "=>", l, r)
    # state_spec subgrammar (non-temporal quantified bodies; same AST as temporal-level operators)
    def state_snot(self, rhs: Spec): return self.snot(rhs)
    def state_sand(self, l: Spec, r: Spec): return self.sand(l, r)
    def state_sor(self, l: Spec, r: Spec): return self.sor(l, r)
    def state_simp(self, l: Spec, r: Spec): return self.simp(l, r)
    def state_sbexp(self, bexp: BExp): return self.sbexp(bexp)
    def state_forall(self, var, domain, body): return self.sforall(var, domain, body)
    def state_exists(self, var, domain, body): return self.sexists(var, domain, body)
    # domains
    def domain_ident(self, name): return DomainIdent(str(name))
    def domain_range(self, lo, hi): return DomainRange(lo, hi)
    def domain_values(self, lit: ListLit): return DomainValues(list(lit.items))
    def domain_type(self, type_node: BasicType): return DomainType(_basic_type_to_decl_type(type_node))
    def domain_var(self, elem_ty: BasicType): return DomainVar(_basic_type_to_decl_type(elem_ty))
    def interval_closed(self, lo, hi): return DomainInterval(lo, hi, left_closed=True, right_closed=True)
    def interval_open(self, lo, hi): return DomainInterval(lo, hi, left_closed=False, right_closed=False)
    def interval_halfopen(self, lo, hi): return DomainInterval(lo, hi, left_closed=True, right_closed=False)
    def interval_halfclosed(self, lo, hi): return DomainInterval(lo, hi, left_closed=False, right_closed=True)
    def sforall(self, var, domain, body): 
        if body.type != SpecType.FOL:
            raise VerifierRuntimeError("LTL formulae cannot be quantified!")
        return SpecQuant(self._next_uid(), SpecType.FOL, "Forall", str(var), domain, body)

    def sexists(self, var, domain, body): 
        if body.type != SpecType.FOL:
            raise VerifierRuntimeError("LTL formulae cannot be quantified!")
        return SpecQuant(self._next_uid(), SpecType.FOL, "Exists", str(var), domain, body)


    def deduce_spec_type(self, spec1 : Spec, spec2: Spec) -> SpecType:
        if spec1.type == spec2.type:
            return spec1.type
        if spec1.type == SpecType.FOL:
            return spec2.type
        if spec2.type == SpecType.FOL:
            return spec2.type
        raise VerifierRuntimeError("Mixed LTL formulae are not allowed!")

    def deduce_past_type(self, spec1: Spec, spec2: Spec) -> SpecType:
        if SpecType.fLTL in {spec1.type, spec2.type}:
            raise VerifierRuntimeError("Mixed LTL formulae are not allowed!")
        return SpecType.pLTL

    def deduce_future_type(self, spec1: Spec, spec2: Spec) -> SpecType:
        if SpecType.pLTL in {spec1.type, spec2.type}:
            raise VerifierRuntimeError("Mixed LTL formulae are not allowed!")
        return SpecType.fLTL


SPEC_PARSER = Lark.open(
    str(Path(__file__).resolve().parent / "grammars" / "spec_grammar.lark"),
    parser="lalr",
    lexer="contextual",
    maybe_placeholders=False,
)


def parse_spec(src: str) -> Spec:
    try:
        tree = SPEC_PARSER.parse(src)
    except LarkError as e:
        raise ParserError("Failed to parse SelVeri specification. " + str(e)) from None
    return SpecAstBuilder().transform(tree)
    
```

---

## Bug 2 — `DomainType.ty` has the exact same type mismatch

**Severity:** 🔴 Crash (AttributeError on first use)

`DomainType.ty` was also constructed from a `BasicType` parser node, but the mapper accessed `domain.ty.kind` — an attribute that only exists on `DeclType`. Any quantifier using a typed domain like `Forall x in Int. ...` would crash with `AttributeError: 'TypeInt' object has no attribute 'kind'`.

**Fix:** Same as Bug 1 — `domain_type` now converts via `_basic_type_to_decl_type` at parse time.

---

## Bug 3 — `map_scope` registers parent variables under wrong scope ID

**Severity:** 🟡 Latent (masked by recursion, wastes memory)

`map_scope` iterated `scope.items()`, which calls `visible_types()` and walks **all** ancestor scopes. But it tagged every variable with the **current** scope's `scope_id`, creating phantom Z3 entries like `_s5_x` for a variable actually declared in scope `_s0`. The subsequent recursion to parent scopes then correctly registered `_s0_x`, so the bug was masked.

**Fix:** Changed to iterate `scope.types.items()` (local variables only). Parents are already handled by the recursive call.

```diff
-        for var, vartype in scope.items():
+        for var, vartype in scope.types.items():  # local scope only; parents handled by recursion
```

---

## Bug 4 — `map_state` has the same parent-variable double-registration

**Severity:** 🟡 Latent (potentially unsound)

Same pattern as Bug 3, but more dangerous: the solver received constraints on phantom Z3 variables (`_s5_x == value`) in addition to the correct ones (`_s0_x == value`). If any specification or mapping ever referenced the phantom variable, the solver could produce wrong results.

**Fix:** Changed to iterate `state.values.items()` (local values only), with an `_UNSET` guard for uninitialized entries.

```diff
-        for var, value in state.items():
-            if var not in scope:
+        for var, value in state.values.items():  # local state only; parents handled by recursion
+            if value is _UNSET:
+                continue
+            if var not in scope.types:
```

---

## Bug 5 — `DomainIdent` list length lookup bypasses scope-aware naming

**Severity:** 🟡 Fragile (breaks with shadowed list names)

The `DomainIdent` branch retrieved list length via `self.state[f"_{domain.name}_len_1"]` — a plain, unscoped name lookup. If two lists with the same name existed in different scopes (shadowing), this could return the wrong length.

**Fix:** Replaced with scope-aware resolution using the list's `DeclType.size` from the owning scope:

```diff
-                # TODO: consider multi-dim lists
-                for i in range(self.state[f"_{domain.name}_len_1"]):
+                owner_scope = self._get_lexical_scope().find_owner(domain.name)
+                ...
+                list_type = owner_scope.types.get(domain.name)
+                ...
+                for i in range(list_type.size):
```

---

## Bug 6 — `_aexp_get_free_variables` silently ignores `ABoundVar`

**Severity:** 🟢 Minor (correct by accident)

The free-variable extractor had no case for `ABoundVar` (quantifier-bound references like `&x`). These silently fell through without being added to the variable set, which happened to be correct — but relied on accidental fall-through rather than explicit intent.

**Fix:** Added explicit handling:

```diff
+        from ..spec_parser import ABoundVar
+        if isinstance(aexp, ABoundVar):
+            pass  # bound variables are not free
```

---

## Bug 7 — `verify_past_LTL` can leave `result` unbound

**Severity:** 🟢 Minor (currently unreachable)

If a `SpecUnOp` or `SpecBinOp` had an unrecognized operator string, the `if/elif` chain would fall through without assigning `result`, causing `UnboundLocalError` at the memoization line. Currently unreachable since the parser only emits known operators, but a defensive gap.

**Fix:** Added `else: raise VerificationError(...)` clauses at the end of both operator chains.

```diff
+            else:
+                raise VerificationError(f"Unsupported unary operator for pLTL: {spec.op}")
```

---

## Bug 8 — Bare `del` on `bound_var_map` in Z3 quantifier branches

**Severity:** 🟢 Minor (currently safe, inconsistent)

The `DomainType`, `DomainRange`, and `DomainInterval` branches used `del self.bound_var_map[bound_var]` instead of the safer `.pop(bound_var, None)`. While the key is always present in these branches, an exception from `map_FOL(spec.body)` would skip cleanup and leave the map polluted.

**Fix:** Changed all three to `.pop(bound_var, None)` for consistency with the finite-domain branch.

---

## Verification

All 13 pass tests and 9 active fail tests produce correct results after the fixes:

```
=== fol_quantifiers.svi === Steps: 103  ✅
=== fol_basic.svi ===      Steps: 31   ✅
=== fol_lists.svi ===      Steps: 164  ✅
=== pltl_basic.svi ===     Steps: 22   ✅
=== pltl_loops.svi ===     Steps: 118  ✅
=== fltl_basic.svi ===     Steps: 39   ✅
... (all 13 pass, 9/9 active fail tests correctly fail)
```



